### PR TITLE
Support Low Power and Sleep Modes

### DIFF
--- a/sht-common/sht.h
+++ b/sht-common/sht.h
@@ -98,7 +98,8 @@ s8 sht_read(s32 *temperature, s32 *humidity);
 
 /**
  * sht_get_driver_version() - Return the driver version
- * Return:  Driver version string
+ *
+ * @return Driver version string
  */
 const char *sht_get_driver_version(void);
 

--- a/sht-common/sht.h
+++ b/sht-common/sht.h
@@ -97,6 +97,13 @@ s8 sht_measure(void);
 s8 sht_read(s32 *temperature, s32 *humidity);
 
 /**
+ * Enable or disable the SHT's low power mode
+ *
+ * @param enable_low_power_mode 1 to enable low power mode, 0 to disable
+ */
+void sht_enable_low_power_mode(u8 enable_low_power_mode);
+
+/**
  * sht_get_driver_version() - Return the driver version
  *
  * @return Driver version string

--- a/sht-common/sht.h
+++ b/sht-common/sht.h
@@ -97,6 +97,17 @@ s8 sht_measure(void);
 s8 sht_read(s32 *temperature, s32 *humidity);
 
 /**
+ * Enable or disable the SHT's sleep mode between measurements, if supported.
+ * Sleep mode is enabled by default when supported.
+ *
+ * @param disable_sleep 1 (or anything other than 0) to disable sleeping between
+ *                      measurements, 0 to enable sleeping.
+ * @return              0 if the command was successful,
+ *                      1 if an error occured or if sleep mode is not supported
+ */
+s8 sht_disable_sleep(u8 disable_sleep);
+
+/**
  * Enable or disable the SHT's low power mode
  *
  * @param enable_low_power_mode 1 to enable low power mode, 0 to disable

--- a/sht3x/sht3x.c
+++ b/sht3x/sht3x.c
@@ -46,8 +46,10 @@
 /* all measurement commands return T (CRC) RH (CRC) */
 #if USE_SENSIRION_CLOCK_STRETCHING
 static const u8 CMD_MEASURE_HPM[]     = { 0x2C, 0x06 };
+static const u8 CMD_MEASURE_LPM[]     = { 0x2C, 0x10 };
 #else
 static const u8 CMD_MEASURE_HPM[]     = { 0x24, 0x00 };
+static const u8 CMD_MEASURE_LPM[]     = { 0x24, 0x16 };
 #endif /* USE_SENSIRION_CLOCK_STRETCHING */
 static const u8 CMD_READ_STATUS_REG[] = { 0xF3, 0x2D };
 static const u8 COMMAND_SIZE = sizeof(CMD_MEASURE_HPM);
@@ -58,6 +60,8 @@ static const u8 SHT3X_ADDRESS = 0x44;
 #endif
 
 static const u16 MEASUREMENT_DURATION_USEC = 15000;
+
+static const u8 *cmd_measure = CMD_MEASURE_HPM;
 
 s8 sht_measure_blocking_read(s32 *temperature, s32 *humidity)
 {
@@ -95,6 +99,11 @@ s8 sht_probe()
     if (ret)
         return ret;
     return STATUS_OK;
+}
+
+void sht_enable_low_power_mode(u8 enable_low_power_mode)
+{
+    cmd_measure = enable_low_power_mode ? CMD_MEASURE_LPM : CMD_MEASURE_HPM;
 }
 
 const char *sht_get_driver_version()

--- a/sht3x/sht3x.c
+++ b/sht3x/sht3x.c
@@ -101,6 +101,11 @@ s8 sht_probe()
     return STATUS_OK;
 }
 
+s8 sht_disable_sleep(u8 disable_sleep)
+{
+    return STATUS_FAIL; /* sleep mode not supported */
+}
+
 void sht_enable_low_power_mode(u8 enable_low_power_mode)
 {
     cmd_measure = enable_low_power_mode ? CMD_MEASURE_LPM : CMD_MEASURE_HPM;

--- a/shtc1/shtc1.c
+++ b/shtc1/shtc1.c
@@ -46,8 +46,10 @@
 /* all measurement commands return T (CRC) RH (CRC) */
 #if USE_SENSIRION_CLOCK_STRETCHING
 static const u8 CMD_MEASURE_HPM[]     = { 0x7C, 0xA2 };
+static const u8 CMD_MEASURE_LPM[]     = { 0x64, 0x58 };
 #else
 static const u8 CMD_MEASURE_HPM[]     = { 0x78, 0x66 };
+static const u8 CMD_MEASURE_LPM[]     = { 0x60, 0x9C };
 static const u16 MEASUREMENT_DURATION_USEC = 14400;
 #endif /* USE_SENSIRION_CLOCK_STRETCHING */
 static const u8 CMD_READ_ID_REG[]     = { 0xef, 0xc8 };
@@ -60,6 +62,8 @@ static const u8 SHTC1_ADDRESS = 0x70;
 
 static const u8 ID_REG_CONTENT    = 0x07;
 static const u8 ID_REG_MASK       = 0x1f;
+
+static const u8 *cmd_measure = CMD_MEASURE_HPM;
 
 s8 sht_measure_blocking_read(s32 *temperature, s32 *humidity)
 {
@@ -102,6 +106,11 @@ s8 sht_probe()
     if ((data[1] & ID_REG_MASK) != ID_REG_CONTENT)
         return STATUS_UNKNOWN_DEVICE;
     return STATUS_OK;
+}
+
+void sht_enable_low_power_mode(u8 enable_low_power_mode)
+{
+    cmd_measure = enable_low_power_mode ? CMD_MEASURE_LPM : CMD_MEASURE_HPM;
 }
 
 const char *sht_get_driver_version()

--- a/shtc1/shtc1.c
+++ b/shtc1/shtc1.c
@@ -153,8 +153,15 @@ s8 sht_probe()
 
     sensirion_i2c_init();
     s8 ret = sensirion_i2c_write(SHTC1_ADDRESS, CMD_READ_ID_REG, COMMAND_SIZE);
-    if (ret)
-        return ret;
+    if (ret) {
+        /* SHTC3 that's sleeping? */
+        if (sht_wakeup())
+            return ret; /* ..no */
+        /* ..potentially, try again */
+        ret = sensirion_i2c_write(SHTC1_ADDRESS, CMD_READ_ID_REG, COMMAND_SIZE);
+        if (ret)
+            return ret;
+    }
 
     ret = sensirion_i2c_read(SHTC1_ADDRESS, data, sizeof(data));
     if (ret)


### PR DESCRIPTION
* Enable low power modes on SHTC1 compatible sensors (SHTC1, SHTW1, SHTW2, SHTC3)
* Recognize an SHTC3 and enable the sleep mode (can be disabled with `sht_disable_sleep_mode(1)`)

smaller fixes: consistent docstring annotations