### PR TITLE
Automated type conversion

### DIFF
--- a/sht-common/example_usage.c
+++ b/sht-common/example_usage.c
@@ -50,11 +50,11 @@ int main(void) {
     /* printf("SHT sensor probing successful\n"); */
 
     while (1) {
-        s32 temperature, humidity;
+        int32_t temperature, humidity;
         /* Measure temperature and relative humidity and store into variables
          * temperature, humidity (each output multiplied by 1000).
          */
-        s8 ret = sht_measure_blocking_read(&temperature, &humidity);
+        int8_t ret = sht_measure_blocking_read(&temperature, &humidity);
         if (ret == STATUS_OK) {
             /* printf("measured temperature: %0.2f degreeCelsius, "
                       "measured humidity: %0.2f percentRH\n",

--- a/sht-common/sht.h
+++ b/sht-common/sht.h
@@ -60,7 +60,7 @@ extern "C" {
  *
  * @return 0 if a sensor was detected
  */
-s8 sht_probe(void);
+int8_t sht_probe(void);
 
 /**
  * Starts a measurement and then reads out the results. This function blocks
@@ -75,7 +75,7 @@ s8 sht_probe(void);
  * measurement
  * @return              0 if the command was successful, else an error code.
  */
-s8 sht_measure_blocking_read(s32 *temperature, s32 *humidity);
+int8_t sht_measure_blocking_read(int32_t *temperature, int32_t *humidity);
 
 /**
  * Starts a measurement in high precision mode. Use sht_read() to read out the
@@ -84,7 +84,7 @@ s8 sht_measure_blocking_read(s32 *temperature, s32 *humidity);
  *
  * @return     0 if the command was successful, else an error code.
  */
-s8 sht_measure(void);
+int8_t sht_measure(void);
 
 /**
  * Reads out the results of a measurement that was previously started by
@@ -99,7 +99,7 @@ s8 sht_measure(void);
  * measurement
  * @return              0 if the command was successful, else an error code.
  */
-s8 sht_read(s32 *temperature, s32 *humidity);
+int8_t sht_read(int32_t *temperature, int32_t *humidity);
 
 /**
  * Enable or disable the SHT's sleep mode between measurements, if supported.
@@ -110,14 +110,14 @@ s8 sht_read(s32 *temperature, s32 *humidity);
  * @return              0 if the command was successful,
  *                      1 if an error occured or if sleep mode is not supported
  */
-s8 sht_disable_sleep(u8 disable_sleep);
+int8_t sht_disable_sleep(uint8_t disable_sleep);
 
 /**
  * Enable or disable the SHT's low power mode
  *
  * @param enable_low_power_mode 1 to enable low power mode, 0 to disable
  */
-void sht_enable_low_power_mode(u8 enable_low_power_mode);
+void sht_enable_low_power_mode(uint8_t enable_low_power_mode);
 
 /**
  * sht_get_driver_version() - Return the driver version
@@ -131,7 +131,7 @@ const char *sht_get_driver_version(void);
  *
  * @return SHTxx_ADDRESS
  */
-u8 sht_get_configured_sht_address(void);
+uint8_t sht_get_configured_sht_address(void);
 
 #ifdef __cplusplus
 }

--- a/sht-common/sht_common.c
+++ b/sht-common/sht_common.c
@@ -41,10 +41,10 @@
 #include "sensirion_i2c.h"
 #include "sht.h"
 
-s8 sht_common_read_ticks(u8 address, s32 *temperature_ticks,
-                         s32 *humidity_ticks) {
-    u8 data[6];
-    s8 ret = sensirion_i2c_read(address, data, sizeof(data));
+int8_t sht_common_read_ticks(uint8_t address, int32_t *temperature_ticks,
+                             int32_t *humidity_ticks) {
+    uint8_t data[6];
+    int8_t ret = sensirion_i2c_read(address, data, sizeof(data));
     if (ret)
         return ret;
     if (sensirion_common_check_crc(data, 2, data[2]) ||
@@ -52,14 +52,15 @@ s8 sht_common_read_ticks(u8 address, s32 *temperature_ticks,
         return STATUS_CRC_FAIL;
     }
 
-    *temperature_ticks = (data[1] & 0xff) | ((s32)data[0] << 8);
-    *humidity_ticks = (data[4] & 0xff) | ((s32)data[3] << 8);
+    *temperature_ticks = (data[1] & 0xff) | ((int32_t)data[0] << 8);
+    *humidity_ticks = (data[4] & 0xff) | ((int32_t)data[3] << 8);
 
     return STATUS_OK;
 }
 
-s8 sht_common_read_measurement(u8 address, s32 *temperature, s32 *humidity) {
-    s8 ret = sht_common_read_ticks(address, temperature, humidity);
+int8_t sht_common_read_measurement(uint8_t address, int32_t *temperature,
+                                   int32_t *humidity) {
+    int8_t ret = sht_common_read_ticks(address, temperature, humidity);
     /**
      * formulas for conversion of the sensor signals, optimized for fixed point
      * algebra: Temperature       = 175 * S_T / 2^16 - 45 Relative Humidity =

--- a/sht-common/sht_common.h
+++ b/sht-common/sht_common.h
@@ -38,10 +38,11 @@
 extern "C" {
 #endif
 
-s8 sht_common_read_ticks(u8 address, s32 *temperature_ticks,
-                         s32 *humidity_ticks);
+int8_t sht_common_read_ticks(uint8_t address, int32_t *temperature_ticks,
+                             int32_t *humidity_ticks);
 
-s8 sht_common_read_measurement(u8 address, s32 *temperature, s32 *humidity);
+int8_t sht_common_read_measurement(uint8_t address, int32_t *temperature,
+                                   int32_t *humidity);
 
 #ifdef __cplusplus
 }

--- a/sht3x/sht3x.c
+++ b/sht3x/sht3x.c
@@ -46,26 +46,26 @@
 
 /* all measurement commands return T (CRC) RH (CRC) */
 #if USE_SENSIRION_CLOCK_STRETCHING
-static const u8 CMD_MEASURE_HPM[] = {0x2C, 0x06};
-static const u8 CMD_MEASURE_LPM[] = {0x2C, 0x10};
+static const uint8_t CMD_MEASURE_HPM[] = {0x2C, 0x06};
+static const uint8_t CMD_MEASURE_LPM[] = {0x2C, 0x10};
 #else
-static const u8 CMD_MEASURE_HPM[] = {0x24, 0x00};
-static const u8 CMD_MEASURE_LPM[] = {0x24, 0x16};
+static const uint8_t CMD_MEASURE_HPM[] = {0x24, 0x00};
+static const uint8_t CMD_MEASURE_LPM[] = {0x24, 0x16};
 #endif /* USE_SENSIRION_CLOCK_STRETCHING */
-static const u8 CMD_READ_STATUS_REG[] = {0xF3, 0x2D};
-static const u8 COMMAND_SIZE = sizeof(CMD_MEASURE_HPM);
+static const uint8_t CMD_READ_STATUS_REG[] = {0xF3, 0x2D};
+static const uint8_t COMMAND_SIZE = sizeof(CMD_MEASURE_HPM);
 #ifdef SHT_ADDRESS
-static const u8 SHT3X_ADDRESS = SHT_ADDRESS;
+static const uint8_t SHT3X_ADDRESS = SHT_ADDRESS;
 #else
-static const u8 SHT3X_ADDRESS = 0x44;
+static const uint8_t SHT3X_ADDRESS = 0x44;
 #endif
 
-static const u16 MEASUREMENT_DURATION_USEC = 15000;
+static const uint16_t MEASUREMENT_DURATION_USEC = 15000;
 
-static const u8 *cmd_measure = CMD_MEASURE_HPM;
+static const uint8_t *cmd_measure = CMD_MEASURE_HPM;
 
-s8 sht_measure_blocking_read(s32 *temperature, s32 *humidity) {
-    s8 ret = sht_measure();
+int8_t sht_measure_blocking_read(int32_t *temperature, int32_t *humidity) {
+    int8_t ret = sht_measure();
     if (ret == STATUS_OK) {
         sensirion_sleep_usec(MEASUREMENT_DURATION_USEC);
         ret = sht_read(temperature, humidity);
@@ -73,18 +73,18 @@ s8 sht_measure_blocking_read(s32 *temperature, s32 *humidity) {
     return ret;
 }
 
-s8 sht_measure() {
+int8_t sht_measure() {
     return sensirion_i2c_write(SHT3X_ADDRESS, CMD_MEASURE_HPM, COMMAND_SIZE);
 }
 
-s8 sht_read(s32 *temperature, s32 *humidity) {
+int8_t sht_read(int32_t *temperature, int32_t *humidity) {
     return sht_common_read_measurement(SHT3X_ADDRESS, temperature, humidity);
 }
 
-s8 sht_probe() {
-    u8 data[3];
+int8_t sht_probe() {
+    uint8_t data[3];
     sensirion_i2c_init();
-    s8 ret =
+    int8_t ret =
         sensirion_i2c_write(SHT3X_ADDRESS, CMD_READ_STATUS_REG, COMMAND_SIZE);
     if (ret)
         return ret;
@@ -99,11 +99,11 @@ s8 sht_probe() {
     return STATUS_OK;
 }
 
-s8 sht_disable_sleep(u8 disable_sleep) {
+int8_t sht_disable_sleep(uint8_t disable_sleep) {
     return STATUS_FAIL; /* sleep mode not supported */
 }
 
-void sht_enable_low_power_mode(u8 enable_low_power_mode) {
+void sht_enable_low_power_mode(uint8_t enable_low_power_mode) {
     cmd_measure = enable_low_power_mode ? CMD_MEASURE_LPM : CMD_MEASURE_HPM;
 }
 
@@ -111,6 +111,6 @@ const char *sht_get_driver_version() {
     return SHT_DRV_VERSION_STR;
 }
 
-u8 sht_get_configured_sht_address() {
+uint8_t sht_get_configured_sht_address() {
     return SHT3X_ADDRESS;
 }

--- a/shtc1/shtc1.c
+++ b/shtc1/shtc1.c
@@ -48,30 +48,30 @@
 
 /* all measurement commands return T (CRC) RH (CRC) */
 #if USE_SENSIRION_CLOCK_STRETCHING
-static const u8 CMD_MEASURE_HPM[] = {0x7C, 0xA2};
-static const u8 CMD_MEASURE_LPM[] = {0x64, 0x58};
+static const uint8_t CMD_MEASURE_HPM[] = {0x7C, 0xA2};
+static const uint8_t CMD_MEASURE_LPM[] = {0x64, 0x58};
 #else
-static const u8 CMD_MEASURE_HPM[] = {0x78, 0x66};
-static const u8 CMD_MEASURE_LPM[] = {0x60, 0x9C};
-static const u16 MEASUREMENT_DURATION_USEC = 14400;
+static const uint8_t CMD_MEASURE_HPM[] = {0x78, 0x66};
+static const uint8_t CMD_MEASURE_LPM[] = {0x60, 0x9C};
+static const uint16_t MEASUREMENT_DURATION_USEC = 14400;
 #endif /* USE_SENSIRION_CLOCK_STRETCHING */
-static const u8 CMD_READ_ID_REG[] = {0xef, 0xc8};
-static const u8 COMMAND_SIZE = sizeof(CMD_MEASURE_HPM);
+static const uint8_t CMD_READ_ID_REG[] = {0xef, 0xc8};
+static const uint8_t COMMAND_SIZE = sizeof(CMD_MEASURE_HPM);
 
-static const u8 SHTC3_CMD_SLEEP[] = {0xB0, 0x98};
-static const u8 SHTC3_CMD_WAKEUP[] = {0x35, 0x17};
+static const uint8_t SHTC3_CMD_SLEEP[] = {0xB0, 0x98};
+static const uint8_t SHTC3_CMD_WAKEUP[] = {0x35, 0x17};
 #ifdef SHT_ADDRESS
-static const u8 SHTC1_ADDRESS = SHT_ADDRESS;
+static const uint8_t SHTC1_ADDRESS = SHT_ADDRESS;
 #else
-static const u8 SHTC1_ADDRESS = 0x70;
+static const uint8_t SHTC1_ADDRESS = 0x70;
 #endif
 
-static const u16 SHTC1_PRODUCT_CODE_MASK = 0x001F;
-static const u16 SHTC1_PRODUCT_CODE = 0x0007;
-static const u16 SHTC3_PRODUCT_CODE_MASK = 0x083F;
-static const u16 SHTC3_PRODUCT_CODE = 0x0807;
+static const uint16_t SHTC1_PRODUCT_CODE_MASK = 0x001F;
+static const uint16_t SHTC1_PRODUCT_CODE = 0x0007;
+static const uint16_t SHTC3_PRODUCT_CODE_MASK = 0x083F;
+static const uint16_t SHTC3_PRODUCT_CODE = 0x0807;
 
-static const u8 *cmd_measure = CMD_MEASURE_HPM;
+static const uint8_t *cmd_measure = CMD_MEASURE_HPM;
 
 /**
  * PM_SLEEP is equivalent to
@@ -98,25 +98,25 @@ static const u8 *cmd_measure = CMD_MEASURE_HPM;
     (((ret) = sht_wakeup()) ? (sht_sleep(), (ret))                             \
                             : ((ret) = (cmd) ? sht_sleep(), (ret) : (ret)))
 
-static u8 supports_sleep = 1;
-static u8 sleep_enabled = 1;
+static uint8_t supports_sleep = 1;
+static uint8_t sleep_enabled = 1;
 
-static u8 sht_sleep() {
+static uint8_t sht_sleep() {
     if (!supports_sleep || !sleep_enabled)
         return STATUS_OK;
 
     return sensirion_i2c_write(SHTC1_ADDRESS, SHTC3_CMD_SLEEP, COMMAND_SIZE);
 }
 
-static u8 sht_wakeup() {
+static uint8_t sht_wakeup() {
     if (!supports_sleep || !sleep_enabled)
         return STATUS_OK;
 
     return sensirion_i2c_write(SHTC1_ADDRESS, SHTC3_CMD_WAKEUP, COMMAND_SIZE);
 }
 
-s8 sht_measure_blocking_read(s32 *temperature, s32 *humidity) {
-    s8 ret;
+int8_t sht_measure_blocking_read(int32_t *temperature, int32_t *humidity) {
+    int8_t ret;
 
     PM_WAKE(ret, sht_measure());
 #if !defined(USE_SENSIRION_CLOCK_STRETCHING) || !USE_SENSIRION_CLOCK_STRETCHING
@@ -126,25 +126,27 @@ s8 sht_measure_blocking_read(s32 *temperature, s32 *humidity) {
     return PM_SLEEP(ret);
 }
 
-s8 sht_measure() {
-    s8 ret;
+int8_t sht_measure() {
+    int8_t ret;
 
     return PM_WAKE(
         ret, sensirion_i2c_write(SHTC1_ADDRESS, cmd_measure, COMMAND_SIZE));
 }
 
-s8 sht_read(s32 *temperature, s32 *humidity) {
-    s8 ret = sht_common_read_measurement(SHTC1_ADDRESS, temperature, humidity);
+int8_t sht_read(int32_t *temperature, int32_t *humidity) {
+    int8_t ret =
+        sht_common_read_measurement(SHTC1_ADDRESS, temperature, humidity);
 
     return PM_SLEEP(ret);
 }
 
-s8 sht_probe() {
-    u8 data[3];
-    u16 id;
+int8_t sht_probe() {
+    uint8_t data[3];
+    uint16_t id;
 
     sensirion_i2c_init();
-    s8 ret = sensirion_i2c_write(SHTC1_ADDRESS, CMD_READ_ID_REG, COMMAND_SIZE);
+    int8_t ret =
+        sensirion_i2c_write(SHTC1_ADDRESS, CMD_READ_ID_REG, COMMAND_SIZE);
     if (ret) {
         /* SHTC3 that's sleeping? */
         if (sht_wakeup())
@@ -163,7 +165,7 @@ s8 sht_probe() {
     if (ret)
         return ret;
 
-    id = ((u16)data[0] << 8) | data[1];
+    id = ((uint16_t)data[0] << 8) | data[1];
     if ((id & SHTC3_PRODUCT_CODE_MASK) == SHTC3_PRODUCT_CODE) {
         supports_sleep = 1;
         return sht_sleep();
@@ -177,7 +179,7 @@ s8 sht_probe() {
     return STATUS_UNKNOWN_DEVICE;
 }
 
-s8 sht_disable_sleep(u8 disable_sleep) {
+int8_t sht_disable_sleep(uint8_t disable_sleep) {
     if (!supports_sleep)
         return STATUS_FAIL;
 
@@ -189,7 +191,7 @@ s8 sht_disable_sleep(u8 disable_sleep) {
     return sht_sleep();
 }
 
-void sht_enable_low_power_mode(u8 enable_low_power_mode) {
+void sht_enable_low_power_mode(uint8_t enable_low_power_mode) {
     cmd_measure = enable_low_power_mode ? CMD_MEASURE_LPM : CMD_MEASURE_HPM;
 }
 
@@ -197,6 +199,6 @@ const char *sht_get_driver_version() {
     return SHT_DRV_VERSION_STR;
 }
 
-u8 sht_get_configured_sht_address() {
+uint8_t sht_get_configured_sht_address() {
     return SHTC1_ADDRESS;
 }


### PR DESCRIPTION
This commit contains changes from the following commands:

    find . -type f \
        \( -name '*\.[ch]' -o -name '*\.cpp' -o -name '*\.ino' \) -print0 \
        | xargs -0 sed -i \
        -e 's/\bu\([0-9]\{1,2\}\)\b/uint\1_t/g' \
        -e 's/\bs\([0-9]\{1,2\}\)\b/int\1_t/g' \
        -e 's/\bf32\b/float32_t/g'
    make style-fix

This commit also updates embedded-common