### PR TITLE
Change return types, use helper functions

### DIFF
--- a/sht3x/sht3x.h
+++ b/sht3x/sht3x.h
@@ -61,7 +61,7 @@ extern "C" {
  *
  * @return 0 if a sensor was detected
  */
-int8_t sht3x_probe(void);
+int16_t sht3x_probe(void);
 
 /**
  * Starts a measurement and then reads out the results. This function blocks
@@ -76,7 +76,7 @@ int8_t sht3x_probe(void);
  * measurement
  * @return              0 if the command was successful, else an error code.
  */
-int8_t sht3x_measure_blocking_read(int32_t *temperature, int32_t *humidity);
+int16_t sht3x_measure_blocking_read(int32_t *temperature, int32_t *humidity);
 
 /**
  * Starts a measurement in high precision mode. Use sht3x_read() to read out the
@@ -85,7 +85,7 @@ int8_t sht3x_measure_blocking_read(int32_t *temperature, int32_t *humidity);
  *
  * @return     0 if the command was successful, else an error code.
  */
-int8_t sht3x_measure(void);
+int16_t sht3x_measure(void);
 
 /**
  * Reads out the results of a measurement that was previously started by
@@ -100,18 +100,7 @@ int8_t sht3x_measure(void);
  * measurement
  * @return              0 if the command was successful, else an error code.
  */
-int8_t sht3x_read(int32_t *temperature, int32_t *humidity);
-
-/**
- * Enable or disable the SHT's sleep mode between measurements, if supported.
- * Sleep mode is enabled by default when supported.
- *
- * @param disable_sleep 1 (or anything other than 0) to disable sleeping between
- *                      measurements, 0 to enable sleeping.
- * @return              0 if the command was successful,
- *                      1 if an error occured or if sleep mode is not supported
- */
-int8_t sht3x_disable_sleep(uint8_t disable_sleep);
+int16_t sht3x_read(int32_t *temperature, int32_t *humidity);
 
 /**
  * Enable or disable the SHT's low power mode

--- a/shtc1/shtc1.h
+++ b/shtc1/shtc1.h
@@ -63,7 +63,7 @@ extern "C" {
  *
  * @return 0 if a sensor was detected
  */
-int8_t shtc1_probe(void);
+int16_t shtc1_probe(void);
 
 /**
  * Starts a measurement and then reads out the results. This function blocks
@@ -78,7 +78,7 @@ int8_t shtc1_probe(void);
  * measurement
  * @return              0 if the command was successful, else an error code.
  */
-int8_t shtc1_measure_blocking_read(int32_t *temperature, int32_t *humidity);
+int16_t shtc1_measure_blocking_read(int32_t *temperature, int32_t *humidity);
 
 /**
  * Starts a measurement in high precision mode. Use shtc1_read() to read out the
@@ -87,7 +87,7 @@ int8_t shtc1_measure_blocking_read(int32_t *temperature, int32_t *humidity);
  *
  * @return     0 if the command was successful, else an error code.
  */
-int8_t shtc1_measure(void);
+int16_t shtc1_measure(void);
 
 /**
  * Reads out the results of a measurement that was previously started by
@@ -102,7 +102,7 @@ int8_t shtc1_measure(void);
  * measurement
  * @return              0 if the command was successful, else an error code.
  */
-int8_t shtc1_read(int32_t *temperature, int32_t *humidity);
+int16_t shtc1_read(int32_t *temperature, int32_t *humidity);
 
 /**
  * Enable or disable the SHT's sleep mode between measurements, if supported.
@@ -113,7 +113,7 @@ int8_t shtc1_read(int32_t *temperature, int32_t *humidity);
  * @return              0 if the command was successful,
  *                      1 if an error occured or if sleep mode is not supported
  */
-int8_t shtc1_disable_sleep(uint8_t disable_sleep);
+int16_t shtc1_disable_sleep(uint8_t disable_sleep);
 
 /**
  * Enable or disable the SHT's low power mode


### PR DESCRIPTION
* Use the sensirion helper functions for reading out commands since
  those incorporate CRC checks and big-endian conversions.
* Fix a potential issue with the readout of the product id (SHTC1) /
  status (SHT3x) happening too quickly after issuing the command that
  could cause probe() to fail since the sensor would not be ready to
  reply yet.
* The helper functions have int16_t return types thus we change the
  return types of all functions to int16_t (harmonizing them with the
  other Sensirion embedded drivers).
* Remove sht3x_disable_sleep. The command stems from when the SHTCx
  and SHT3x had a common header file, the SHT3x never supported sleep
  and always returned a failure.