### PR TITLE
Put build and deploy into same workflow

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -68,11 +68,9 @@ jobs:
 
 workflows:
   version: 2
-  build:
+  build_and_deploy:
     jobs:
       - build
-  deploy:
-    jobs:
       - deploy:
           requires:
             - build


### PR DESCRIPTION
Previously they were in a separate workflow, but deploy required build which didn't exist. See https://circleci.com/workflow-run/a3bd954a-0a20-4bd5-ba99-1c0a6d4d9acc.