### PR TITLE
SHTC3 Manual sleeping

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+ * [`changed`]  Replace SHTC3's auto-sleeping with manual sleeping for better
+                control of the sensor and easier-to-read code.
+                - Adds the functions `shtc1_sleep()` and `shtc1_wake_up()`
+                  Despite the name, the functions only work on the SHTC3.
+                - Remove `shtc1_disable_sleeping()`.
+
 ## [4.1.0] - 2019-09-13
 
  * [`fixed`]    Fix warnings about sign conversion

--- a/shtc1/shtc1.c
+++ b/shtc1/shtc1.c
@@ -53,7 +53,6 @@
 #define SHTC1_CMD_MEASURE_HPM 0x7866
 #define SHTC1_CMD_MEASURE_LPM 0x609C
 #endif /* USE_SENSIRION_CLOCK_STRETCHING */
-static const uint16_t SHTC1_CMD_READ_ID_REG = 0xefc8;
 static const uint16_t SHTC1_CMD_DURATION_USEC = 1000;
 
 static const uint16_t SHTC3_CMD_SLEEP = 0xB098;
@@ -63,11 +62,6 @@ static const uint8_t SHTC1_ADDRESS = SHT_ADDRESS;
 #else
 static const uint8_t SHTC1_ADDRESS = 0x70;
 #endif
-
-static const uint16_t SHTC1_PRODUCT_CODE_MASK = 0x001F;
-static const uint16_t SHTC1_PRODUCT_CODE = 0x0007;
-static const uint16_t SHTC3_PRODUCT_CODE_MASK = 0x083F;
-static const uint16_t SHTC3_PRODUCT_CODE = 0x0807;
 
 static uint16_t shtc1_cmd_measure = SHTC1_CMD_MEASURE_HPM;
 

--- a/shtc1/shtc1.h
+++ b/shtc1/shtc1.h
@@ -53,8 +53,6 @@ extern "C" {
 #define STATUS_ERR_BAD_DATA (-1)
 #define STATUS_CRC_FAIL (-2)
 #define STATUS_UNKNOWN_DEVICE (-3)
-#define STATUS_WAKEUP_FAILED (-4)
-#define STATUS_SLEEP_FAILED (-5)
 #define SHTC1_MEASUREMENT_DURATION_USEC 14400
 
 /**
@@ -106,15 +104,58 @@ int16_t shtc1_measure(void);
 int16_t shtc1_read(int32_t *temperature, int32_t *humidity);
 
 /**
- * Enable or disable the SHT's sleep mode between measurements, if supported.
- * Sleep mode is enabled by default when supported.
+ * Send the sensor to sleep, if supported.
  *
- * @param disable_sleep 1 (or anything other than 0) to disable sleeping between
- *                      measurements, 0 to enable sleeping.
- * @return              0 if the command was successful,
- *                      1 if an error occured or if sleep mode is not supported
+ * Note: DESPITE THE NAME, THIS COMMAND IS ONLY AVAILABLE FOR THE SHTC3
+ *
+ * Usage:
+ * ```
+ * int16_t ret;
+ * int32_t temperature, humidity;
+ * ret = shtc1_wake_up();
+ * if (ret) {
+ *     // error waking up
+ * }
+ * ret = shtc1_measure_blocking_read(&temperature, &humidity);
+ * if (ret) {
+ *     // error measuring
+ * }
+ * ret = shtc1_sleep();
+ * if (ret) {
+ *     // error sending sensor to sleep
+ * }
+ * ```
+ *
+ * @return  0 if the command was successful, else an error code.
  */
-int16_t shtc1_disable_sleep(uint8_t disable_sleep);
+int16_t shtc1_sleep();
+
+/**
+ * Wake the sensor from sleep
+ *
+ * Note: DESPITE THE NAME, THIS COMMAND IS ONLY AVAILABLE FOR THE SHTC3
+ *
+ * Usage:
+ * ```
+ * int16_t ret;
+ * int32_t temperature, humidity;
+ * ret = shtc1_wake_up();
+ * if (ret) {
+ *     // error waking up
+ * }
+ * ret = shtc1_measure_blocking_read(&temperature, &humidity);
+ * if (ret) {
+ *     // error measuring
+ * }
+ * ret = shtc1_sleep();
+ * if (ret) {
+ *     // error sending sensor to sleep
+ * }
+ * ```
+ *
+ * @return  0 if the command was successful, else an error code.
+ */
+int16_t shtc1_wake_up();
 
 /**
  * Enable or disable the SHT's low power mode


### PR DESCRIPTION
 Interface Change: Remove auto-sleeping behavior

Remove the auto-sleeping behavior and replace it with an interface for
manual sleep control.

The rationale for this is that the automatic sleeping may not always
be what you expect but mostly, it makes the code much harder to read.

* Remove shtc1_disable_sleep()
* Remove STATUS_WAKEUP_FAILED, STATUS_SLEEP_FAILED. Both are not
  needed anymore, since the result is clear from the dedicated methods
  shtc1_sleep() and shtc1_wake_up() failing
* New shtc1_sleep() sends an SHTC3 (despite the function name) to
  sleep.
* New shtc1_wake_up() wakes up an SHTC3 from sleep.