### PR TITLE
Copy correct files to release directory

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -1,9 +1,0 @@
-Andreas Brauchli <andreas.brauchli@sensirion.com>
-Christian Jaeggi <christian.jaeggi@sensirion.com>
-Pascal Sachs <pascal.sachs@sensirion.com>
-Daniel Lehmann <Daniel.Lehmann@sensirion.com>
-David Frey <david.frey@sensirion.com>
-Jerome Sieber <jsieber@sensirion.com>
-Salomon Diether <salomon.diether@sensirion.com>
-Silvan Fischer <silvan.fischer@sensirion.com>
-Sven Gruebel <Sven.Gruebel@sensirion.com>

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
                 - Adds the functions `shtc1_sleep()` and `shtc1_wake_up()`
                   Despite the name, the functions only work on the SHTC3.
                 - Remove `shtc1_disable_sleeping()`.
+ * [`removed`]  Remove the `AUTHORS` file from the driver and the
+                `embedded-common` submodule, as it adds more noise than benefit.
+                The contributors can be found in the git log.
 
 ## [4.1.0] - 2019-09-13
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
  * [`removed`]  Remove the `AUTHORS` file from the driver and the
                 `embedded-common` submodule, as it adds more noise than benefit.
                 The contributors can be found in the git log.
+ * [`fixed`]    Copy correct `CHANGELOG.md` and `LICENSE` files to target
+                locations when running the `release` target of the driver's root
+                Makefile.
 
 ## [4.1.0] - 2019-09-13
 

--- a/Makefile
+++ b/Makefile
@@ -35,8 +35,7 @@ $(release_drivers): sht-common/sht_git_version.c
 	cp CHANGELOG.md LICENSE "$${pkgdir}" && \
 	echo 'sensirion_common_dir = .' >> $${pkgdir}/user_config.inc && \
 	echo 'sht_common_dir = .' >> $${pkgdir}/user_config.inc && \
-	echo 'sht3x_dir = .' >> $${pkgdir}/user_config.inc && \
-	echo 'shtc1_dir = .' >> $${pkgdir}/user_config.inc && \
+	echo "$${driver}_dir = ." >> $${pkgdir}/user_config.inc && \
 	cd "$${pkgdir}" && $(MAKE) $(MFLAGS) && $(MAKE) clean $(MFLAGS) && cd - && \
 	cd release && zip -r "$${pkgname}.zip" "$${pkgname}" && cd - && \
 	ln -sfn $${pkgname} $@

--- a/Makefile
+++ b/Makefile
@@ -32,6 +32,7 @@ $(release_drivers): sht-common/sht_git_version.c
 	cp -r embedded-common/* "$${pkgdir}" && \
 	cp -r sht-common/* "$${pkgdir}" && \
 	cp -r $${driver}/* "$${pkgdir}" && \
+	cp CHANGELOG.md LICENSE "$${pkgdir}" && \
 	echo 'sensirion_common_dir = .' >> $${pkgdir}/user_config.inc && \
 	echo 'sht_common_dir = .' >> $${pkgdir}/user_config.inc && \
 	echo 'sht3x_dir = .' >> $${pkgdir}/user_config.inc && \


### PR DESCRIPTION
The files `AUTHORS`, `CHANGELOG.md`, `LICENSE`, and `README.md` in the
release directories were copied from the `embedded-common` submodule
instead of the driver's root folder. Fix this issue by overwriting the
files with the correct files.