### PR TITLE
Fix uVision compilation warnings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
  * [`fixed`]    Copy correct `CHANGELOG.md` and `LICENSE` files to target
                 locations when running the `release` target of the driver's root
                 Makefile.
+ * [`fixed`]    Fix uVision compilation warnings (#1295-D: Deprecated
+                declaration of shtc1_sleep - give arg types)
 
 ## [4.1.0] - 2019-09-13
 

--- a/sht3x/sht3x.c
+++ b/sht3x/sht3x.c
@@ -73,7 +73,7 @@ int16_t sht3x_measure_blocking_read(int32_t *temperature, int32_t *humidity) {
     return ret;
 }
 
-int16_t sht3x_measure() {
+int16_t sht3x_measure(void) {
     return sensirion_i2c_write_cmd(SHT3X_ADDRESS, sht3x_cmd_measure);
 }
 

--- a/shtc1/shtc1.c
+++ b/shtc1/shtc1.c
@@ -65,11 +65,11 @@ static const uint8_t SHTC1_ADDRESS = 0x70;
 
 static uint16_t shtc1_cmd_measure = SHTC1_CMD_MEASURE_HPM;
 
-int16_t shtc1_sleep() {
+int16_t shtc1_sleep(void) {
     return sensirion_i2c_write_cmd(SHTC1_ADDRESS, SHTC3_CMD_SLEEP);
 }
 
-int16_t shtc1_wake_up() {
+int16_t shtc1_wake_up(void) {
     return sensirion_i2c_write_cmd(SHTC1_ADDRESS, SHTC3_CMD_WAKEUP);
 }
 

--- a/shtc1/shtc1.h
+++ b/shtc1/shtc1.h
@@ -128,7 +128,7 @@ int16_t shtc1_read(int32_t *temperature, int32_t *humidity);
  *
  * @return  0 if the command was successful, else an error code.
  */
-int16_t shtc1_sleep();
+int16_t shtc1_sleep(void);
 
 /**
  * Wake the sensor from sleep
@@ -155,7 +155,7 @@ int16_t shtc1_sleep();
  *
  * @return  0 if the command was successful, else an error code.
  */
-int16_t shtc1_wake_up();
+int16_t shtc1_wake_up(void);
 
 /**
  * Enable or disable the SHT's low power mode


### PR DESCRIPTION
uVision complains that the functions `shtc1_wake_up()`, `shtc1_sleep()`
and `sht3x_measure()` do not have any arguments declared:

>shtc1\shtc1.h(131): warning: #1295-D: Deprecated declaration
>shtc1_sleep - give arg types

Fix these warnings by setting the arguments to `void`.