### PR TITLE
Rename SHTC1 functions to distinguish SHTC3 from others

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
                 Makefile.
  * [`fixed`]    Fix uVision compilation warnings (#1295-D: Deprecated
                 declaration of shtc1_sleep - give arg types)
+ * [`changed`]  Change the function name prefix to `shtcx_` for all functions
+                that work with all sensors of the SHTC1 family (SHTC1, SHTW2,
+                SHTC3) and to `shtc3_` for all functions that only work with an
+                SHTC3 sensor.
 
 ## [4.1.0] - 2019-09-13
 

--- a/sample-projects/shtc3-stm32-uvision/Source/main.c
+++ b/sample-projects/shtc3-stm32-uvision/Source/main.c
@@ -49,7 +49,7 @@ int main(void) {
     /* Busy loop for initialization, because the main loop does not work without
      * a sensor.
      */
-    while (shtc1_probe() != STATUS_OK) {
+    while (shtcx_probe() != STATUS_OK) {
         /* Blink LED as long as probing fails */
         led_green(true);
         sensirion_sleep_usec(100000);
@@ -65,7 +65,7 @@ int main(void) {
         /* Measure temperature and relative humidity and store into variables
          * temperature, humidity (each output multiplied by 1000).
          */
-        int8_t ret = shtc1_measure_blocking_read(&temperature, &humidity);
+        int8_t ret = shtcx_measure_blocking_read(&temperature, &humidity);
         if (ret == STATUS_OK) {
             led_green(true);
             /* if the Relative Humidity is over 50% light up the blue LED */

--- a/shtc1/shtc1.c
+++ b/shtc1/shtc1.c
@@ -47,51 +47,51 @@
 
 /* all measurement commands return T (CRC) RH (CRC) */
 #if USE_SENSIRION_CLOCK_STRETCHING
-#define SHTC1_CMD_MEASURE_HPM 0x7CA2
-#define SHTC1_CMD_MEASURE_LPM 0x6458
+#define SHTCX_CMD_MEASURE_HPM 0x7CA2
+#define SHTCX_CMD_MEASURE_LPM 0x6458
 #else /* USE_SENSIRION_CLOCK_STRETCHING */
-#define SHTC1_CMD_MEASURE_HPM 0x7866
-#define SHTC1_CMD_MEASURE_LPM 0x609C
+#define SHTCX_CMD_MEASURE_HPM 0x7866
+#define SHTCX_CMD_MEASURE_LPM 0x609C
 #endif /* USE_SENSIRION_CLOCK_STRETCHING */
-static const uint16_t SHTC1_CMD_DURATION_USEC = 1000;
+static const uint16_t SHTCX_CMD_DURATION_USEC = 1000;
 
 static const uint16_t SHTC3_CMD_SLEEP = 0xB098;
 static const uint16_t SHTC3_CMD_WAKEUP = 0x3517;
 #ifdef SHT_ADDRESS
-static const uint8_t SHTC1_ADDRESS = SHT_ADDRESS;
+static const uint8_t SHTCX_ADDRESS = SHT_ADDRESS;
 #else
-static const uint8_t SHTC1_ADDRESS = 0x70;
+static const uint8_t SHTCX_ADDRESS = 0x70;
 #endif
 
-static uint16_t shtc1_cmd_measure = SHTC1_CMD_MEASURE_HPM;
+static uint16_t shtcx_cmd_measure = SHTCX_CMD_MEASURE_HPM;
 
-int16_t shtc1_sleep(void) {
-    return sensirion_i2c_write_cmd(SHTC1_ADDRESS, SHTC3_CMD_SLEEP);
+int16_t shtc3_sleep(void) {
+    return sensirion_i2c_write_cmd(SHTCX_ADDRESS, SHTC3_CMD_SLEEP);
 }
 
-int16_t shtc1_wake_up(void) {
-    return sensirion_i2c_write_cmd(SHTC1_ADDRESS, SHTC3_CMD_WAKEUP);
+int16_t shtc3_wake_up(void) {
+    return sensirion_i2c_write_cmd(SHTCX_ADDRESS, SHTC3_CMD_WAKEUP);
 }
 
-int16_t shtc1_measure_blocking_read(int32_t *temperature, int32_t *humidity) {
+int16_t shtcx_measure_blocking_read(int32_t *temperature, int32_t *humidity) {
     int16_t ret;
 
-    ret = shtc1_measure();
+    ret = shtcx_measure();
     if (ret)
         return ret;
 #if !defined(USE_SENSIRION_CLOCK_STRETCHING) || !USE_SENSIRION_CLOCK_STRETCHING
-    sensirion_sleep_usec(SHTC1_MEASUREMENT_DURATION_USEC);
+    sensirion_sleep_usec(SHTCX_MEASUREMENT_DURATION_USEC);
 #endif /* USE_SENSIRION_CLOCK_STRETCHING */
-    return shtc1_read(temperature, humidity);
+    return shtcx_read(temperature, humidity);
 }
 
-int16_t shtc1_measure(void) {
-    return sensirion_i2c_write_cmd(SHTC1_ADDRESS, shtc1_cmd_measure);
+int16_t shtcx_measure(void) {
+    return sensirion_i2c_write_cmd(SHTCX_ADDRESS, shtcx_cmd_measure);
 }
 
-int16_t shtc1_read(int32_t *temperature, int32_t *humidity) {
+int16_t shtcx_read(int32_t *temperature, int32_t *humidity) {
     uint16_t words[2];
-    int16_t ret = sensirion_i2c_read_words(SHTC1_ADDRESS, words,
+    int16_t ret = sensirion_i2c_read_words(SHTCX_ADDRESS, words,
                                            SENSIRION_NUM_WORDS(words));
     /**
      * formulas for conversion of the sensor signals, optimized for fixed point
@@ -105,37 +105,37 @@ int16_t shtc1_read(int32_t *temperature, int32_t *humidity) {
     return ret;
 }
 
-int16_t shtc1_probe(void) {
+int16_t shtcx_probe(void) {
     uint32_t serial;
 
-    (void)shtc1_wake_up(); /* Try to wake up the sensor, ignore return value */
-    return shtc1_read_serial(&serial);
+    (void)shtc3_wake_up(); /* Try to wake up the sensor, ignore return value */
+    return shtcx_read_serial(&serial);
 }
 
-void shtc1_enable_low_power_mode(uint8_t enable_low_power_mode) {
-    shtc1_cmd_measure =
-        enable_low_power_mode ? SHTC1_CMD_MEASURE_LPM : SHTC1_CMD_MEASURE_HPM;
+void shtcx_enable_low_power_mode(uint8_t enable_low_power_mode) {
+    shtcx_cmd_measure =
+        enable_low_power_mode ? SHTCX_CMD_MEASURE_LPM : SHTCX_CMD_MEASURE_HPM;
 }
 
-int16_t shtc1_read_serial(uint32_t *serial) {
+int16_t shtcx_read_serial(uint32_t *serial) {
     int16_t ret;
     const uint16_t tx_words[] = {0x007B};
     uint16_t serial_words[SENSIRION_NUM_WORDS(*serial)];
 
-    ret = sensirion_i2c_write_cmd_with_args(SHTC1_ADDRESS, 0xC595, tx_words,
+    ret = sensirion_i2c_write_cmd_with_args(SHTCX_ADDRESS, 0xC595, tx_words,
                                             SENSIRION_NUM_WORDS(tx_words));
     if (ret)
         return ret;
 
-    sensirion_sleep_usec(SHTC1_CMD_DURATION_USEC);
+    sensirion_sleep_usec(SHTCX_CMD_DURATION_USEC);
 
     ret = sensirion_i2c_delayed_read_cmd(
-        SHTC1_ADDRESS, 0xC7F7, SHTC1_CMD_DURATION_USEC, &serial_words[0], 1);
+        SHTCX_ADDRESS, 0xC7F7, SHTCX_CMD_DURATION_USEC, &serial_words[0], 1);
     if (ret)
         return ret;
 
     ret = sensirion_i2c_delayed_read_cmd(
-        SHTC1_ADDRESS, 0xC7F7, SHTC1_CMD_DURATION_USEC, &serial_words[1], 1);
+        SHTCX_ADDRESS, 0xC7F7, SHTCX_CMD_DURATION_USEC, &serial_words[1], 1);
     if (ret)
         return ret;
 
@@ -143,10 +143,10 @@ int16_t shtc1_read_serial(uint32_t *serial) {
     return ret;
 }
 
-const char *shtc1_get_driver_version(void) {
+const char *shtcx_get_driver_version(void) {
     return SHT_DRV_VERSION_STR;
 }
 
-uint8_t shtc1_get_configured_address(void) {
-    return SHTC1_ADDRESS;
+uint8_t shtcx_get_configured_address(void) {
+    return SHTCX_ADDRESS;
 }

--- a/shtc1/shtc1.h
+++ b/shtc1/shtc1.h
@@ -38,8 +38,8 @@
  * interface. It supports measurements without clock stretching only.
  */
 
-#ifndef SHTC1_H
-#define SHTC1_H
+#ifndef SHTCX_H
+#define SHTCX_H
 
 #include "sensirion_arch_config.h"
 #include "sensirion_i2c.h"
@@ -53,7 +53,7 @@ extern "C" {
 #define STATUS_ERR_BAD_DATA (-1)
 #define STATUS_CRC_FAIL (-2)
 #define STATUS_UNKNOWN_DEVICE (-3)
-#define SHTC1_MEASUREMENT_DURATION_USEC 14400
+#define SHTCX_MEASUREMENT_DURATION_USEC 14400
 
 /**
  * Detects if a sensor is connected by reading out the ID register.
@@ -62,7 +62,7 @@ extern "C" {
  *
  * @return 0 if a sensor was detected
  */
-int16_t shtc1_probe(void);
+int16_t shtcx_probe(void);
 
 /**
  * Starts a measurement and then reads out the results. This function blocks
@@ -77,20 +77,20 @@ int16_t shtc1_probe(void);
  * measurement
  * @return              0 if the command was successful, else an error code.
  */
-int16_t shtc1_measure_blocking_read(int32_t *temperature, int32_t *humidity);
+int16_t shtcx_measure_blocking_read(int32_t *temperature, int32_t *humidity);
 
 /**
- * Starts a measurement in high precision mode. Use shtc1_read() to read out the
+ * Starts a measurement in high precision mode. Use shtcx_read() to read out the
  * values, once the measurement is done. The duration of the measurement depends
  * on the sensor in use, please consult the datasheet.
  *
  * @return     0 if the command was successful, else an error code.
  */
-int16_t shtc1_measure(void);
+int16_t shtcx_measure(void);
 
 /**
  * Reads out the results of a measurement that was previously started by
- * shtc1_measure(). If the measurement is still in progress, this function
+ * shtcx_measure(). If the measurement is still in progress, this function
  * returns an error.
  * Temperature is returned in [degree Celsius], multiplied by 1000,
  * and relative humidity in [percent relative humidity], multiplied by 1000.
@@ -101,26 +101,26 @@ int16_t shtc1_measure(void);
  * measurement
  * @return              0 if the command was successful, else an error code.
  */
-int16_t shtc1_read(int32_t *temperature, int32_t *humidity);
+int16_t shtcx_read(int32_t *temperature, int32_t *humidity);
 
 /**
  * Send the sensor to sleep, if supported.
  *
- * Note: DESPITE THE NAME, THIS COMMAND IS ONLY AVAILABLE FOR THE SHTC3
+ * As the name suggests, this command is only available for the SHTC3
  *
  * Usage:
  * ```
  * int16_t ret;
  * int32_t temperature, humidity;
- * ret = shtc1_wake_up();
+ * ret = shtc3_wake_up();
  * if (ret) {
  *     // error waking up
  * }
- * ret = shtc1_measure_blocking_read(&temperature, &humidity);
+ * ret = shtcx_measure_blocking_read(&temperature, &humidity);
  * if (ret) {
  *     // error measuring
  * }
- * ret = shtc1_sleep();
+ * ret = shtc3_sleep();
  * if (ret) {
  *     // error sending sensor to sleep
  * }
@@ -128,26 +128,26 @@ int16_t shtc1_read(int32_t *temperature, int32_t *humidity);
  *
  * @return  0 if the command was successful, else an error code.
  */
-int16_t shtc1_sleep(void);
+int16_t shtc3_sleep(void);
 
 /**
  * Wake the sensor from sleep
  *
- * Note: DESPITE THE NAME, THIS COMMAND IS ONLY AVAILABLE FOR THE SHTC3
+ * As the name suggests, this command is only available for the SHTC3
  *
  * Usage:
  * ```
  * int16_t ret;
  * int32_t temperature, humidity;
- * ret = shtc1_wake_up();
+ * ret = shtc3_wake_up();
  * if (ret) {
  *     // error waking up
  * }
- * ret = shtc1_measure_blocking_read(&temperature, &humidity);
+ * ret = shtcx_measure_blocking_read(&temperature, &humidity);
  * if (ret) {
  *     // error measuring
  * }
- * ret = shtc1_sleep();
+ * ret = shtc3_sleep();
  * if (ret) {
  *     // error sending sensor to sleep
  * }
@@ -155,14 +155,14 @@ int16_t shtc1_sleep(void);
  *
  * @return  0 if the command was successful, else an error code.
  */
-int16_t shtc1_wake_up(void);
+int16_t shtc3_wake_up(void);
 
 /**
  * Enable or disable the SHT's low power mode
  *
  * @param enable_low_power_mode 1 to enable low power mode, 0 to disable
  */
-void shtc1_enable_low_power_mode(uint8_t enable_low_power_mode);
+void shtcx_enable_low_power_mode(uint8_t enable_low_power_mode);
 
 /**
  * Read out the serial number
@@ -170,24 +170,24 @@ void shtc1_enable_low_power_mode(uint8_t enable_low_power_mode);
  * @param serial    the address for the result of the serial number
  * @return          0 if the command was successful, else an error code.
  */
-int16_t shtc1_read_serial(uint32_t *serial);
+int16_t shtcx_read_serial(uint32_t *serial);
 
 /**
  * Return the driver version
  *
  * @return Driver version string
  */
-const char *shtc1_get_driver_version(void);
+const char *shtcx_get_driver_version(void);
 
 /**
  * Returns the configured SHT3x address.
  *
- * @return SHT3x_ADDRESS
+ * @return SHTCX_ADDRESS
  */
-uint8_t shtc1_get_configured_address(void);
+uint8_t shtcx_get_configured_address(void);
 
 #ifdef __cplusplus
 }
 #endif
 
-#endif /* SHTC1_H */
+#endif /* SHTCX_H */

--- a/shtc1/shtc1_example_usage.c
+++ b/shtc1/shtc1_example_usage.c
@@ -46,7 +46,7 @@ int main(void) {
     /* Busy loop for initialization, because the main loop does not work without
      * a sensor.
      */
-    while (shtc1_probe() != STATUS_OK) {
+    while (shtcx_probe() != STATUS_OK) {
         /* printf("SHT sensor probing failed\n"); */
     }
     /* printf("SHT sensor probing successful\n"); */
@@ -56,7 +56,7 @@ int main(void) {
         /* Measure temperature and relative humidity and store into variables
          * temperature, humidity (each output multiplied by 1000).
          */
-        int8_t ret = shtc1_measure_blocking_read(&temperature, &humidity);
+        int8_t ret = shtcx_measure_blocking_read(&temperature, &humidity);
         if (ret == STATUS_OK) {
             /* printf("measured temperature: %0.2f degreeCelsius, "
                       "measured humidity: %0.2f percentRH\n",


### PR DESCRIPTION
Certain functions of the SHTC1 driver only work with SHTC3 sensors. To
have a better idea of what function works with which sensor, we change
the function name prefix to `shtcx_` for all functions that work for all
sensors of the SHTC1 family (SHTC1, SHTW2, SHTC3) and to `shtc3_` for
all functions that only work with an SHTC3.