### PR TITLE
Provide conversion functions: C<->F and T, RH -> AH

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
                 Makefile.
  * [`fixed`]    Fix uVision compilation warnings (#1295-D: Deprecated
                 declaration of shtc1_sleep - give arg types)
+ * [`added`]    Add convenience function convert relative to absolute humidity
+ * [`added`]    Add convenience functions convert between Celsius and Fahrenheit
 
 ## [4.1.0] - 2019-09-13
 

--- a/Makefile
+++ b/Makefile
@@ -4,9 +4,10 @@ clean_drivers=$(foreach d, $(drivers), clean_$(d))
 release_drivers=$(foreach d, $(drivers), release/$(d))
 release_sample_projects=$(foreach s, $(sample-projects), release/$(s))
 
-.PHONY: FORCE all $(release_drivers) $(clean_drivers) style-check style-fix
+.PHONY: FORCE all $(release_drivers) $(clean_drivers) style-check style-fix \
+	    utils clean_utils
 
-all: prepare $(drivers)
+all: prepare $(drivers) utils
 
 prepare: sht-common/sht_git_version.c
 
@@ -54,13 +55,20 @@ $(release_sample_projects):
 
 release: clean $(release_drivers) $(release_sample_projects)
 
+utils:
+	$(MAKE) -C utils
+
+clean_utils:
+	$(MAKE) -C utils clean
+
 $(clean_drivers):
 	export rel=$@ && \
 	export driver=$${rel#clean_} && \
 	cd $${driver} && $(MAKE) clean $(MFLAGS) && cd -
 
-clean: $(clean_drivers)
-	rm -rf release sht-common/sht_git_version.c
+clean: $(clean_drivers) clean_utils
+	rm -rf release
+	$(RM) sht-common/sht_git_version.c
 
 style-fix:
 	@if [ $$(git status --porcelain -uno 2> /dev/null | wc -l) -gt "0" ]; \

--- a/README.md
+++ b/README.md
@@ -15,10 +15,10 @@ cloning the repository.
 ```
 
 ## Repository content
-* embedded-common (submodule repository for the common embedded driver HAL)
-* sht-common (common files for all SHTxx drivers)
-* sht3x (SHT3x/SHT8x driver related)
-* shtc1 (SHTC3/SHTC1/SHTW1/SHTW2 driver related)
+* `embedded-common` submodule repository for the common embedded driver HAL
+* `sht-common` common files for all SHTxx drivers, humidity conversion functions
+* `sht3x` SHT3x/SHT8x driver related
+* `shtc1` SHTC3/SHTC1/SHTW1/SHTW2 driver related
 
 ## Collecting resources
 ```
@@ -32,7 +32,7 @@ ready to build your driver for your platform.
 You only need to touch the following files:
 
 * `sensirion_arch_config.h` (architecture specifics, you need to specify
-the integer sizes)
+  the integer sizes)
 
 and depending on your i2c implementation either of the following:
 
@@ -42,7 +42,7 @@ and depending on your i2c implementation either of the following:
   functions for software i2c communication via GPIOs
 
 ## Building the driver
-1. Adjust sensirion\_arch\_config.h if you don't have the `<stdint.h>` header
+1. Adjust `sensirion_arch_config.h` if you don't have the `<stdint.h>` header
    file available
 2. Implement necessary functions in one of the `*_implementation.c` files
    described above

--- a/sht3x/sht3x.c
+++ b/sht3x/sht3x.c
@@ -83,8 +83,8 @@ int16_t sht3x_read(int32_t *temperature, int32_t *humidity) {
                                            SENSIRION_NUM_WORDS(words));
     /**
      * formulas for conversion of the sensor signals, optimized for fixed point
-     * algebra: Temperature       = 175 * S_T / 2^16 - 45 Relative Humidity =
-     * 100 * S_RH / 2^16
+     * algebra: Temperature = 175 * S_T / 2^16 - 45
+     * Relative Humidity = * 100 * S_RH / 2^16
      */
     *temperature = ((21875 * (int32_t)words[0]) >> 13) - 45000;
     *humidity = ((12500 * (int32_t)words[1]) >> 13);

--- a/utils/Makefile
+++ b/utils/Makefile
@@ -2,9 +2,15 @@ include default_config.inc
 
 .PHONY: clean
 
-all: $(sensirion_humidity_conversion_sources:.c=.o)
+obj = sensirion_temperature_unit_conversion.o \
+      sensirion_humidity_conversion.o
 
-%.o: %.c %.h
+all: $(obj)
+
+sensirion_temperature_unit_conversion.o: $(sensirion_temperature_unit_conversion_sources)
+	$(CC) $(CFLAGS) -shared -o $@ $<
+
+sensirion_humidity_conversion.o: $(sensirion_humidity_conversion_sources)
 	$(CC) $(CFLAGS) -shared -o $@ $<
 
 clean:

--- a/utils/Makefile
+++ b/utils/Makefile
@@ -1,0 +1,11 @@
+include default_config.inc
+
+.PHONY: clean
+
+all: $(sensirion_humidity_conversion_sources:.c=.o)
+
+%.o: %.c %.h
+	$(CC) $(CFLAGS) -shared -o $@ $<
+
+clean:
+	$(RM) $(obj)

--- a/utils/ah_lut.py
+++ b/utils/ah_lut.py
@@ -1,0 +1,134 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+"""
+(c) Copyright 2018 Sensirion AG, Switzerland
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are met:
+
+* Redistributions of source code must retain the above copyright notice, this
+  list of conditions and the following disclaimer.
+
+* Redistributions in binary form must reproduce the above copyright notice,
+  this list of conditions and the following disclaimer in the documentation
+  and/or other materials provided with the distribution.
+
+* Neither the name of Sensirion AG nor the names of its
+  contributors may be used to endorse or promote products derived from
+  this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+POSSIBILITY OF SUCH DAMAGE.
+"""
+
+import math
+
+
+# Generate a look-up table for the interpolation of the relative humidity to
+# absolute humidity conversion within a specifig temperature region (e.g. -20°C
+# to 70°C in steps of 10°C)
+# As part of the output, the mean error over each discrete (t, rh) point within
+# a region of interest is printed (See `quantify_ah_lut_error`)
+
+def calc_ah(t, rh):
+    """ Mathematically correct AH computation """
+    return 216.7 * (
+            (rh / 100. * 6.112 * math.exp(17.62 * t / (243.12 + t))) /
+            (273.15 + t))
+
+
+def gen_ah_lut(t_range):
+    """ Generate the AH Look Up Table at 100%RH (0..100 scales linearly) """
+    return [calc_ah(t, 100) for t in t_range]
+
+
+def ah_lookup(ah_lut, t_lo, t_hi, temp, rh):
+    if rh == 0:
+        return 0
+
+    t_step = (t_hi - t_lo) / (len(ah_lut) - 1)
+    t = temp - t_lo
+    i = int(t / t_step)
+    rem = t % t_step
+
+    if i >= len(ah_lut) - 1:
+        return ah_lut[-1] * (rh / 100.)
+
+    if rem == 0:
+        return ah_lut[i] * (rh / 100.)
+    return (ah_lut[i] + (ah_lut[i + 1] - ah_lut[i]) * rem / t_step) * rh / 100.
+
+
+def c_ah_lookup(ah_lut, t_lo, t_hi, temp, rh):
+    """ Fixed point implementation (for C conversion)
+    The only non-fixed point aspect is the final division by 1000. for
+    comparison with the floating point version """
+    if rh == 0:
+        return 0
+
+    rh = int(rh * 1000)
+    norm_humi = (rh * 82) >> 13
+    temp = int(temp * 1000)
+    t_lo = int(t_lo * 1000)
+    t_hi = int(t_hi * 1000)
+
+    t_step = int((t_hi - t_lo) / (len(ah_lut) - 1))
+    t = temp - t_lo
+    i = int(t / t_step)
+    rem = t % t_step
+
+    if i >= len(ah_lut) - 1:
+        return (ah_lut[-1] * norm_humi) / 1000.
+    if rem == 0:
+        return (ah_lut[i] * norm_humi) / 1000.
+
+    return ((ah_lut[i] + (ah_lut[i + 1] - ah_lut[i]) * rem / t_step) * norm_humi) / 1000.
+
+
+def quantify_ah_lut_error(ah_lut, t_lo, t_hi, t_range, rh_range):
+    s_float = 0
+    s_int = 0
+    for t in t_range:
+        for rh in rh_range:
+            s_float += abs(calc_ah(t, rh) - ah_lookup(ah_lut, t_lo, t_hi, t, rh))
+            s_int += abs(calc_ah(t, rh) - c_ah_lookup(ah_lut, t_lo, t_hi, t, rh))
+    div = (len(t_range) * len(rh_range))
+    return (s_float / div, s_int / div)
+
+
+if __name__ == '__main__':
+    T_LO = -20
+    T_HI = 70
+    T_STEP = 10
+    lut = gen_ah_lut(range(T_LO, T_HI+1, T_STEP))
+    print("The average absolute error over the range in 1°C steps is:")
+    print("error avg(abs(ah(t,rh) - lookup(t,rh))) for T: -20..45, RH: 20..80 (float, int)")
+    print(quantify_ah_lut_error(lut, T_LO, T_HI, range(T_LO, 45, 1), range(20, 80, 1)))
+
+    # print("Comparison of the absolute humdity to the lookup-table value over a
+    #       "selected set of (T, %RH) pairs")
+    # for t, rh in [(-20, 0), (-20, 100), (-19.9, 100), (-15.1, 90), (-15, 90),
+    #         (-14.9, 90), (20, 50), (20, 100), (22.5, 50),  (55, 70),  (65, 70), (75, 70), (140, 50)]:
+    #     print("AH({}, {}) = {} ~ {} ~ {}".format(t, rh, calc_ah(t, rh),
+    #                                         ah_lookup(lut, T_LO, T_HI, t, rh),
+    #                                         c_ah_lookup(lut, T_LO, T_HI, t, rh)))
+
+    print("")
+    print("C Source:")
+    print("""
+#define T_LO ({t_low})
+#define T_HI ({t_high})
+static const uint32_t AH_LUT_100RH[] = {{{ah_lut_100rh}}};"""
+          .format(t_low=T_LO, t_high=T_HI,
+                  ah_lut_100rh=', '.join(['{:.0f}'.format(ah * 1000)
+                                          for ah in lut])))

--- a/utils/default_config.inc
+++ b/utils/default_config.inc
@@ -8,3 +8,7 @@ CFLAGS += -I${sht_utils_dir} -I${sensirion_common_dir}
 sensirion_humidity_conversion_sources = \
     ${sht_utils_dir}/sensirion_humidity_conversion.h \
     ${sht_utils_dir}/sensirion_humidity_conversion.c
+
+sensirion_temperature_unit_conversion_sources = \
+    ${sht_utils_dir}/sensirion_temperature_unit_conversion.h \
+    ${sht_utils_dir}/sensirion_temperature_unit_conversion.c

--- a/utils/default_config.inc
+++ b/utils/default_config.inc
@@ -1,0 +1,10 @@
+sht_driver_dir ?= ..
+sensirion_common_dir ?= ${sht_driver_dir}/embedded-common
+sht_utils_dir ?= ${sht_driver_dir}/utils
+
+CFLAGS ?= -Os -Wall -fstrict-aliasing -Wstrict-aliasing=1 -Wsign-conversion -fPIC
+CFLAGS += -I${sht_utils_dir} -I${sensirion_common_dir}
+
+sensirion_humidity_conversion_sources = \
+    ${sht_utils_dir}/sensirion_humidity_conversion.h \
+    ${sht_utils_dir}/sensirion_humidity_conversion.c

--- a/utils/sensirion_humidity_conversion.c
+++ b/utils/sensirion_humidity_conversion.c
@@ -1,0 +1,104 @@
+/*
+ * Copyright (c) 2020, Sensirion AG
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * * Redistributions of source code must retain the above copyright notice, this
+ *   list of conditions and the following disclaimer.
+ *
+ * * Redistributions in binary form must reproduce the above copyright notice,
+ *   this list of conditions and the following disclaimer in the documentation
+ *   and/or other materials provided with the distribution.
+ *
+ * * Neither the name of Sensirion AG nor the names of its
+ *   contributors may be used to endorse or promote products derived from
+ *   this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include "sensirion_humidity_conversion.h"
+
+#ifndef ARRAY_SIZE
+#define ARRAY_SIZE(x) (sizeof(x) / sizeof(*(x)))
+#endif /* ARRAY_SIZE */
+
+/* T_LO and T_HI parametrize the first and last temperature step of the absolute
+ * humidity lookup table (at 100%RH). The lookup table entries have to be
+ * linearly spaced. We provide a python script to generate look up tables based
+ * on customizable T_LO/T_HI and number of steps. */
+
+/**
+ * T_LO - Towest temperature sampling point in the lookup table.
+ * Temperature value in milli-degrees Centigrade
+ */
+#define T_LO (-20000)
+
+/**
+ * T_HI - Towest temperature sampling point in the lookup table.
+ * Temperature value in milli-degrees Celsius (Centigrade)
+ */
+#define T_HI (70000)
+
+/**
+ * Lookup table for linearly spaced temperature points between T_LO and T_HI
+ * Absolute Humidity value in mg/m^3.
+ */
+static const uint32_t AH_LUT_100RH[] = {1078,  2364,  4849,  9383,   17243,
+                                        30264, 50983, 82785, 130048, 198277};
+/**
+ * T_STEP is the temperature step between the sampling points in the lookup
+ * table. It is determined by T_HI, T_LO and the number of entries in
+ * AH_LUT_100RH and does not have to be adapted when changing the paramters.
+ */
+static const uint32_t T_STEP = (T_HI - T_LO) / (ARRAY_SIZE(AH_LUT_100RH) - 1);
+
+uint32_t sensirion_calc_absolute_humidity(int32_t temperature_milli_celsius,
+                                          int32_t humidity_milli_percent) {
+    uint32_t t, i, rem, ret;
+
+    if (humidity_milli_percent <= 0)
+        return 0;
+
+    if (temperature_milli_celsius < T_LO)
+        t = 0;
+    else
+        t = (uint32_t)(temperature_milli_celsius - T_LO);
+
+    i = t / T_STEP;
+    rem = t % T_STEP;
+
+    if (i >= ARRAY_SIZE(AH_LUT_100RH) - 1) {
+        ret = AH_LUT_100RH[ARRAY_SIZE(AH_LUT_100RH) - 1];
+
+    } else if (rem == 0) {
+        ret = AH_LUT_100RH[i];
+
+    } else {
+        ret = (AH_LUT_100RH[i] +
+               ((AH_LUT_100RH[i + 1] - AH_LUT_100RH[i]) * rem / T_STEP));
+    }
+
+    // Code is mathematically (but not numerically) equivalent to
+    //    return (ret * (humidity_milli_percent)) / 100000;
+    // Maximum ret = 198277 (Or last entry from AH_LUT_100RH)
+    // Maximum humidity_milli_percent = 119000 (theoretical maximum)
+    // Multiplication might overflow with a maximum of 3 digits
+    // Trick: ((ret >> 3) * (uint32_t)humidity_milli_percent) never overflows
+    // Now we only need to divide by 12500, as the tripple righ shift
+    // divides by 8
+
+    return ((ret >> 3) * (uint32_t)(humidity_milli_percent)) / 12500;
+}

--- a/utils/sensirion_humidity_conversion.h
+++ b/utils/sensirion_humidity_conversion.h
@@ -1,0 +1,60 @@
+/*
+ * Copyright (c) 2020, Sensirion AG
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * * Redistributions of source code must retain the above copyright notice, this
+ *   list of conditions and the following disclaimer.
+ *
+ * * Redistributions in binary form must reproduce the above copyright notice,
+ *   this list of conditions and the following disclaimer in the documentation
+ *   and/or other materials provided with the distribution.
+ *
+ * * Neither the name of Sensirion AG nor the names of its
+ *   contributors may be used to endorse or promote products derived from
+ *   this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#ifndef HUMIDITY_CONVERSION_H
+#define HUMIDITY_CONVERSION_H
+#include "sensirion_arch_config.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/**
+ * sensirion_calc_absolute_humidity() - Calculate absolute humidity from
+ *                                      temperature and relative humidity
+ *
+ * @param temperature_milli_celsius The temperature measurement in milli Degree
+ *                                  Celsius, i.e. degree celsius multiplied by
+ *                                  1000.
+ * @param humidity_milli_percent    The relative humidity measurement in
+ *                                  milli Percent, i.e.  percent relative
+ *                                  humidity, multiplied by 1000 (0-100000)
+ *
+ * @return                          The absolute humidity in mg/m^3
+ */
+uint32_t sensirion_calc_absolute_humidity(int32_t temperature_milli_celsius,
+                                          int32_t humidity_milli_percent);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* HUMIDITY_CONVERSION_H */

--- a/utils/sensirion_temperature_unit_conversion.c
+++ b/utils/sensirion_temperature_unit_conversion.c
@@ -1,0 +1,47 @@
+/*
+ * Copyright (c) 2020, Sensirion AG
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * * Redistributions of source code must retain the above copyright notice, this
+ *   list of conditions and the following disclaimer.
+ *
+ * * Redistributions in binary form must reproduce the above copyright notice,
+ *   this list of conditions and the following disclaimer in the documentation
+ *   and/or other materials provided with the distribution.
+ *
+ * * Neither the name of Sensirion AG nor the names of its
+ *   contributors may be used to endorse or promote products derived from
+ *   this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include "sensirion_temperature_unit_conversion.h"
+
+int32_t sensirion_celsius_to_fahrenheit(int32_t temperature_milli_celsius) {
+    /* Conversion equivalent to: temperature_milli_celsius * 9.0/5.0 + 32000
+     * Fixed Point: 9.0/5.0 * 2^12 = 7372.8
+     * Using int32_t sized two's complement for negatives */
+    return ((temperature_milli_celsius * 7373) >> 12) + 32000;
+}
+
+int32_t sensirion_fahrenheit_to_celsius(int32_t temperature_milli_fahrenheit) {
+    /* Conversion equivalent to:
+     * (temperature_milli_fahrenheit - 32000) * 5.0/9.0
+     * Fixed Point: 5.0/9.0 * 2^10 = 568.9
+     * Using int32_t sized two's complement for negatives */
+    return ((temperature_milli_fahrenheit - 32000) * 569) >> 10;
+}

--- a/utils/sensirion_temperature_unit_conversion.h
+++ b/utils/sensirion_temperature_unit_conversion.h
@@ -1,0 +1,78 @@
+/*
+ * Copyright (c) 2020, Sensirion AG
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * * Redistributions of source code must retain the above copyright notice, this
+ *   list of conditions and the following disclaimer.
+ *
+ * * Redistributions in binary form must reproduce the above copyright notice,
+ *   this list of conditions and the following disclaimer in the documentation
+ *   and/or other materials provided with the distribution.
+ *
+ * * Neither the name of Sensirion AG nor the names of its
+ *   contributors may be used to endorse or promote products derived from
+ *   this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#ifndef SENSIRION_TEMPERATURE_UNIT_CONVERSION_H
+#define SENSIRION_TEMPERATURE_UNIT_CONVERSION_H
+#include "sensirion_arch_config.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/**
+ * sensirion_celsius_to_fahrenheit() - Convert temperature in degree Celsius
+ *                                     (Centigrade) to degree Fahrenheit
+ *
+ * Note that inputs not in the range -291degC <= degC <= 291 will result in
+ * invalid results.
+ *
+ * @param temperature_milli_celsius     The temperature measurement in milli
+ *                                      degree Celsius, i.e. degree Celsius
+ *                                      multiplied by 1000.
+ *
+ * @return                              The temperature measurement in milli
+ *                                      degree Fahrenheit, i.e. degree
+ *                                      Fahrenheit multiplied by 1000.
+ */
+int32_t sensirion_celsius_to_fahrenheit(int32_t temperature_milli_celsius);
+
+/**
+ * sensirion_fahrenheit_to_celsius() - Convert temperature in degree Fahrenheit
+ *                                     to degree Celsius (Centigrade)
+ *
+ * Note that inputs not in the range -3571degF <= degF <= 3635degF will result
+ * in invalid results.
+ *
+ * @param temperature_milli_fahrenheit  The temperature measurement in milli
+ *                                      degree Fahrenheit, i.e. degree
+ *                                      Fahrenheit multiplied by 1000.
+ *
+ * @return                              The temperature measurement in milli
+ *                                      degree Celsius, i.e. degree Celsius
+ *                                      multiplied by 1000.
+ */
+int32_t sensirion_fahrenheit_to_celsius(int32_t temperature_milli_fahrenheit);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* SENSIRION_TEMPERATURE_UNIT_CONVERSION_H */


### PR DESCRIPTION
* Provide convenience temperature conversion functions to convert a
  temperature/relative-humidity pair to absolute humidity using
  space-efficient and embedded-hardware friendly fixed-point
  conversions using a pre-generated look-up table.
* `ah_lut.py` is the script to generate the look-up table.
* Makefile to build the conversion function (mainly for testing)