### PR TITLE
Fix images in release documentation

### DIFF
--- a/sample-projects/shtc3-stm32-uvision/prepare_release.sh
+++ b/sample-projects/shtc3-stm32-uvision/prepare_release.sh
@@ -12,7 +12,7 @@ BASE_DIR=$(dirname "$0")
 # Copy everything
 cp -r "${BASE_DIR}/"* "$1"
 # Create documentation
-pandoc --variable urlcolor=cyan -s -o "$1"/README.pdf "$1"/RELEASE_DOC.md
+(cd "$1" && pandoc --variable urlcolor=cyan -s -o README.pdf RELEASE_DOC.md)
 # Delete unneeded files
 rm "$1"/copy_shtc1_driver.sh
 rm "$1"/prepare_release.sh


### PR DESCRIPTION
For the relative links to the images to work, pandoc must be executed in
the same directory as the main .md file lives.