### PR TITLE
Add pull request info

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,6 @@
+Check the following:
+
+ - [ ] Breaking changes marked in commit message
+ - [ ] Changelog updated
+ - [ ] Code style cleaned (ran `make style-fix`)
+ - [ ] Tested on actual hardware


### PR DESCRIPTION
Add the file pull_request_template.md in the .github folder.
This shows additional information when a pull request is created.