### PR TITLE
Fix example files to print by default

### DIFF
--- a/sht3x/sht3x_example_usage.c
+++ b/sht3x/sht3x_example_usage.c
@@ -29,15 +29,14 @@
  * POSSIBILITY OF SUCH DAMAGE.
  */
 
-/* #include <stdio.h> // printf
- * #include <unistd.h> // sleep
- */
-#include "sht3x.h"
+#include <stdio.h>  // printf
 
-/**
- * TO USE CONSOLE OUTPUT (PRINTF) AND WAIT (SLEEP) PLEASE ADAPT THEM TO YOUR
- * PLATFORM
+/* TO USE CONSOLE OUTPUT (printf) YOU MAY NEED TO ADAPT THE
+ * INCLUDE ABOVE OR DEFINE IT ACCORDING TO YOUR PLATFORM.
+ * #define printf(...)
  */
+
+#include "sht3x.h"
 
 int main(void) {
     /* Initialize the i2c bus for the current platform */
@@ -47,9 +46,9 @@ int main(void) {
      * a sensor.
      */
     while (sht3x_probe() != STATUS_OK) {
-        /* printf("SHT sensor probing failed\n"); */
+        printf("SHT sensor probing failed\n");
     }
-    /* printf("SHT sensor probing successful\n"); */
+    printf("SHT sensor probing successful\n");
 
     while (1) {
         int32_t temperature, humidity;
@@ -58,15 +57,14 @@ int main(void) {
          */
         int8_t ret = sht3x_measure_blocking_read(&temperature, &humidity);
         if (ret == STATUS_OK) {
-            /* printf("measured temperature: %0.2f degreeCelsius, "
-                      "measured humidity: %0.2f percentRH\n",
-                      temperature / 1000.0f,
-                      humidity / 1000.0f); */
+            printf("measured temperature: %0.2f degreeCelsius, "
+                   "measured humidity: %0.2f percentRH\n",
+                   temperature / 1000.0f, humidity / 1000.0f);
         } else {
-            /* printf("error reading measurement\n"); */
+            printf("error reading measurement\n");
         }
 
-        /* sleep(1); */
+        sensirion_sleep_usec(1000000);
     }
     return 0;
 }

--- a/shtc1/shtc1_example_usage.c
+++ b/shtc1/shtc1_example_usage.c
@@ -29,15 +29,14 @@
  * POSSIBILITY OF SUCH DAMAGE.
  */
 
-/* #include <stdio.h> // printf
- * #include <unistd.h> // sleep
- */
-#include "shtc1.h"
+#include <stdio.h>  // printf
 
-/**
- * TO USE CONSOLE OUTPUT (PRINTF) AND WAIT (SLEEP) PLEASE ADAPT THEM TO YOUR
- * PLATFORM
+/* TO USE CONSOLE OUTPUT (printf) YOU MAY NEED TO ADAPT THE
+ * INCLUDE ABOVE OR DEFINE IT ACCORDING TO YOUR PLATFORM.
+ * #define printf(...)
  */
+
+#include "shtc1.h"
 
 int main(void) {
     /* Initialize the i2c bus for the current platform */
@@ -47,9 +46,9 @@ int main(void) {
      * a sensor.
      */
     while (shtc1_probe() != STATUS_OK) {
-        /* printf("SHT sensor probing failed\n"); */
+        printf("SHT sensor probing failed\n");
     }
-    /* printf("SHT sensor probing successful\n"); */
+    printf("SHT sensor probing successful\n");
 
     while (1) {
         int32_t temperature, humidity;
@@ -58,15 +57,14 @@ int main(void) {
          */
         int8_t ret = shtc1_measure_blocking_read(&temperature, &humidity);
         if (ret == STATUS_OK) {
-            /* printf("measured temperature: %0.2f degreeCelsius, "
-                      "measured humidity: %0.2f percentRH\n",
-                      temperature / 1000.0f,
-                      humidity / 1000.0f); */
+            printf("measured temperature: %0.2f degreeCelsius, "
+                   "measured humidity: %0.2f percentRH\n",
+                   temperature / 1000.0f, humidity / 1000.0f);
         } else {
-            /* printf("error reading measurement\n"); */
+            printf("error reading measurement\n");
         }
 
-        /* sleep(1); */
+        sensirion_sleep_usec(1000000);
     }
     return 0;
 }


### PR DESCRIPTION
- Uncommment printf and sleep from shtc1_example_usage.c
  file so by default it prints out status messages.
- Uncommment printf and sleep from sht3x_example_usage.c
  file so by default it prints out status messages.

Check the following:

 - [ ] Breaking changes marked in commit message
 - [ ] Changelog updated
 - [ ] Code style cleaned (ran `make style-fix`)
 - [ ] Tested on actual hardware
