### PR TITLE
Replace i2c_reset calls with sensirion_i2c_general_call_reset

### DIFF
--- a/tests/sht3x-test.cpp
+++ b/tests/sht3x-test.cpp
@@ -1,3 +1,4 @@
+#include "sensirion_common.h"
 #include "sensirion_test_setup.h"
 #include "sht3x.h"
 
@@ -49,8 +50,8 @@ static void sht3x_test_all_power_modes() {
 }
 
 static void test_teardown() {
-    int16_t ret = i2c_reset();
-    CHECK_ZERO_TEXT(ret, "i2c_reset");
+    int16_t ret = sensirion_i2c_general_call_reset();
+    CHECK_ZERO_TEXT(ret, "sensirion_i2c_general_call_reset");
     sensirion_i2c_release();
 }
 

--- a/tests/sht4x-test.cpp
+++ b/tests/sht4x-test.cpp
@@ -1,3 +1,4 @@
+#include "sensirion_common.h"
 #include "sensirion_test_setup.h"
 #include "sht4x.h"
 
@@ -49,8 +50,8 @@ static void sht4x_test_all_power_modes() {
 }
 
 static void test_teardown() {
-    int16_t ret = i2c_reset();
-    CHECK_ZERO_TEXT(ret, "i2c_reset");
+    int16_t ret = sensirion_i2c_general_call_reset();
+    CHECK_ZERO_TEXT(ret, "sensirion_i2c_general_call_reset");
     sensirion_i2c_release();
 }
 

--- a/tests/shtc1-test.cpp
+++ b/tests/shtc1-test.cpp
@@ -74,8 +74,8 @@ static void shtc1_sleep_fail() {
 }
 
 static void test_teardown() {
-    int16_t ret = i2c_reset();
-    CHECK_ZERO_TEXT(ret, "i2c_reset");
+    int16_t ret = sensirion_i2c_general_call_reset();
+    CHECK_ZERO_TEXT(ret, "sensirion_i2c_general_call_reset");
     sensirion_i2c_release();
 }
 


### PR DESCRIPTION
i2c_reset is deprecated and just calls into
sensirion_i2c_general_call_reset.

Check the following:

 - [na] Breaking changes marked in commit message
 - [na] Changelog updated
 - [x] Code style cleaned (ran `make style-fix`)
 - [x] Tested on actual hardware
