### PR TITLE
Update embedded-common to 0.1.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
  * [`changed`] Makefile to only include needed files from embedded-common
+ * [`changed`] Updated embedded-common to 0.1.0 to improve compatibility when
+               using multiple embedded drivers
 
 ## [5.2.0] - 2020-09-10
 


### PR DESCRIPTION
This improves compatibility when using multiple embedded drivers at the
same time, since the version of embedded-common must be the same.

Check the following:

 - [na] Breaking changes marked in commit message
 - [x] Changelog updated
 - [x] Code style cleaned (ran `make style-fix`)
 - [x] Tested on actual hardware
