### PR TITLE
sht3x: allow dynamic addressing to 0x44 and 0x45 with I2C address enum

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+ * [`changed`] SHT3x driver added macros to easily parse the STATUS register relevant bits
+ * [`changed`] SHT3x driver support for alrt thresholds configuration (read ans write commands)
+ * [`changed`] SHT3x driver support for clear status register
+ * [`changed`] SHT3x driver allows use of 2 sensors in parallel (addresses 0x44 & 0x45) 
+
 ## [5.2.1] - 2020-12-14
 
  * [`changed`] Makefile to only include needed files from embedded-common

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,9 +6,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
  * [`changed`] SHT3x driver added macros to easily parse the STATUS register relevant bits
- * [`changed`] SHT3x driver support for alrt thresholds configuration (read ans write commands)
+ * [`changed`] SHT3x driver support for alert thresholds configuration (read and write commands)
  * [`changed`] SHT3x driver support for clear status register
- * [`changed`] SHT3x driver allows use of 2 sensors in parallel (addresses 0x44 & 0x45) 
+ * [`changed`] SHT3x driver allows use of 2 sensors in parallel (addresses 0x44 & 0x45)
 
 ## [5.2.1] - 2020-12-14
 

--- a/sht3x/sht3x.c
+++ b/sht3x/sht3x.c
@@ -165,12 +165,8 @@ int16_t sht3x_read_serial(sht3x_i2c_addr_t addr, uint32_t* serial) {
     return ret;
 }
 
-const char* sht3x_get_driver_version(sht3x_i2c_addr_t addr) {
+const char* sht3x_get_driver_version(void) {
     return SHT_DRV_VERSION_STR;
-}
-
-uint8_t sht3x_get_configured_address(sht3x_i2c_addr_t addr) {
-    return addr;
 }
 
 int16_t sht3x_set_alert_thd(sht3x_i2c_addr_t addr, sht3x_alert_thd_t thd,
@@ -179,13 +175,13 @@ int16_t sht3x_set_alert_thd(sht3x_i2c_addr_t addr, sht3x_alert_thd_t thd,
     uint32_t tmp;
     uint16_t limitVal = 0U;
 
-    /* convert inputs to alrt threshold word */
-    tmp = (humidity << 16) - humidity;
+    /* convert inputs to alert threshold word */
+    tmp = humidity * 65535U;
     tmp = tmp / 1000U; /*humidity was provided in 10%RH*/
     limitVal = ((uint16_t)tmp & SHT3X_HUMIDITY_LIMIT_MSK);
 
     tmp = (uint32_t)(temperature + 450);
-    tmp = (tmp << 16) - tmp;
+    tmp = tmp * 65535U;
     tmp = tmp / 1750U;
     tmp = (tmp >> 7);
     limitVal |= ((uint16_t)tmp & SHT3X_TEMPERATURE_LIMIT_MSK);
@@ -251,7 +247,7 @@ int16_t sht3x_get_alert_thd(sht3x_i2c_addr_t addr, sht3x_alert_thd_t thd,
             break;
     }
 
-    /* convert threshold word to alrt settings in 10*%RH & 10*°C */
+    /* convert threshold word to alert settings in 10*%RH & 10*°C */
     tmp = (int32_t)(word & SHT3X_HUMIDITY_LIMIT_MSK); /*only 7MSbits*/
     tmp = (1000 * tmp) / 65535;
     *humidity = tmp;

--- a/sht3x/sht3x.c
+++ b/sht3x/sht3x.c
@@ -46,14 +46,31 @@
 /* all measurement commands return T (CRC) RH (CRC) */
 #if USE_SENSIRION_CLOCK_STRETCHING
 #define SHT3X_CMD_MEASURE_HPM 0x2C06
+#define SHT3X_CMD_MEASURE_MPM 0x2C0D
 #define SHT3X_CMD_MEASURE_LPM 0x2C10
 #else /* USE_SENSIRION_CLOCK_STRETCHING */
 #define SHT3X_CMD_MEASURE_HPM 0x2400
+#define SHT3X_CMD_MEASURE_MPM 0x240B
 #define SHT3X_CMD_MEASURE_LPM 0x2416
 #endif /* USE_SENSIRION_CLOCK_STRETCHING */
+
+#define SHT3X_HUMIDITY_LIMIT_MSK 0xFE00U
+#define SHT3X_TEMPERATURE_LIMIT_MSK 0x01FFU
+
 static const uint16_t SHT3X_CMD_READ_STATUS_REG = 0xF32D;
+static const uint16_t SHT3X_CMD_CLR_STATUS_REG = 0x3041;
 static const uint16_t SHT3X_CMD_READ_SERIAL_ID = 0x3780;
 static const uint16_t SHT3X_CMD_DURATION_USEC = 1000;
+/* read commands for the alert settings */
+static const uint16_t SHT3X_CMD_READ_HIALRT_LIM_SET = 0xE11F;
+static const uint16_t SHT3X_CMD_READ_HIALRT_LIM_CLR = 0xE114;
+static const uint16_t SHT3X_CMD_READ_LOALRT_LIM_CLR = 0xE109;
+static const uint16_t SHT3X_CMD_READ_LOALRT_LIM_SET = 0xE102;
+/* write commands for the alert settings */
+static const uint16_t SHT3X_CMD_WRITE_HIALRT_LIM_SET = 0x611D;
+static const uint16_t SHT3X_CMD_WRITE_HIALRT_LIM_CLR = 0x6116;
+static const uint16_t SHT3X_CMD_WRITE_LOALRT_LIM_CLR = 0x610B;
+static const uint16_t SHT3X_CMD_WRITE_LOALRT_LIM_SET = 0x6100;
 
 static uint16_t sht3x_cmd_measure = SHT3X_CMD_MEASURE_HPM;
 
@@ -95,9 +112,41 @@ int16_t sht3x_probe(sht3x_i2c_addr_t addr) {
                                           SHT3X_CMD_DURATION_USEC, &status, 1);
 }
 
+int16_t sht3x_get_status(sht3x_i2c_addr_t addr, uint16_t* status) {
+    return sensirion_i2c_delayed_read_cmd(addr, SHT3X_CMD_READ_STATUS_REG,
+                                          SHT3X_CMD_DURATION_USEC, status, 1);
+}
+
+int16_t sht3x_clear_status(sht3x_i2c_addr_t addr) {
+    return sensirion_i2c_write_cmd(addr, SHT3X_CMD_CLR_STATUS_REG);
+}
+
 void sht3x_enable_low_power_mode(uint8_t enable_low_power_mode) {
     sht3x_cmd_measure =
         enable_low_power_mode ? SHT3X_CMD_MEASURE_LPM : SHT3X_CMD_MEASURE_HPM;
+}
+
+void sht3x_set_power_mode(sht3x_measurement_mode_t mode) {
+
+    switch (mode) {
+        case SHT3X_MEAS_MODE_LPM: {
+            sht3x_cmd_measure = SHT3X_CMD_MEASURE_LPM;
+            break;
+        }
+        case SHT3X_MEAS_MODE_MPM: {
+            sht3x_cmd_measure = SHT3X_CMD_MEASURE_MPM;
+            break;
+        }
+        case SHT3X_MEAS_MODE_HPM: {
+            sht3x_cmd_measure = SHT3X_CMD_MEASURE_HPM;
+            break;
+        }
+        default: {
+            sht3x_cmd_measure = SHT3X_CMD_MEASURE_HPM;
+            break;
+        }
+    }
+    return;
 }
 
 int16_t sht3x_read_serial(sht3x_i2c_addr_t addr, uint32_t* serial) {
@@ -122,4 +171,96 @@ const char* sht3x_get_driver_version(sht3x_i2c_addr_t addr) {
 
 uint8_t sht3x_get_configured_address(sht3x_i2c_addr_t addr) {
     return addr;
+}
+
+int16_t sht3x_set_alert_thd(sht3x_i2c_addr_t addr, sht3x_alert_thd_t thd,
+                            uint16_t humidity, int16_t temperature) {
+    int16_t ret;
+    uint32_t tmp;
+    uint16_t limitVal = 0U;
+
+    /* convert inputs to alrt threshold word */
+    tmp = (humidity << 16) - humidity;
+    tmp = tmp / 1000U; /*humidity was provided in 10%RH*/
+    limitVal = ((uint16_t)tmp & SHT3X_HUMIDITY_LIMIT_MSK);
+
+    tmp = (uint32_t)(temperature + 450);
+    tmp = (tmp << 16) - tmp;
+    tmp = tmp / 1750U;
+    tmp = (tmp >> 7);
+    limitVal |= ((uint16_t)tmp & SHT3X_TEMPERATURE_LIMIT_MSK);
+
+    switch (thd) {
+        case SHT3X_HIALRT_SET:
+            ret = sensirion_i2c_write_cmd_with_args(
+                addr, SHT3X_CMD_WRITE_HIALRT_LIM_SET, &limitVal, 1);
+            break;
+
+        case SHT3X_HIALRT_CLR:
+            ret = sensirion_i2c_write_cmd_with_args(
+                addr, SHT3X_CMD_WRITE_HIALRT_LIM_CLR, &limitVal, 1);
+            break;
+
+        case SHT3X_LOALRT_CLR:
+            ret = sensirion_i2c_write_cmd_with_args(
+                addr, SHT3X_CMD_WRITE_LOALRT_LIM_CLR, &limitVal, 1);
+            break;
+
+        case SHT3X_LOALRT_SET:
+            ret = sensirion_i2c_write_cmd_with_args(
+                addr, SHT3X_CMD_WRITE_LOALRT_LIM_SET, &limitVal, 1);
+            break;
+
+        default:
+            ret = STATUS_ERR_INVALID_PARAMS;
+            break;
+    }
+    return ret;
+}
+
+int16_t sht3x_get_alert_thd(sht3x_i2c_addr_t addr, sht3x_alert_thd_t thd,
+                            uint16_t* humidity, int16_t* temperature) {
+
+    int16_t ret;
+    uint16_t word;
+    int32_t tmp;
+
+    switch (thd) {
+        case SHT3X_HIALRT_SET:
+            ret = sensirion_i2c_read_cmd(addr, SHT3X_CMD_READ_HIALRT_LIM_SET,
+                                         &word, 1);
+            break;
+
+        case SHT3X_HIALRT_CLR:
+            ret = sensirion_i2c_read_cmd(addr, SHT3X_CMD_READ_HIALRT_LIM_CLR,
+                                         &word, 1);
+            break;
+
+        case SHT3X_LOALRT_CLR:
+            ret = sensirion_i2c_read_cmd(addr, SHT3X_CMD_READ_LOALRT_LIM_CLR,
+                                         &word, 1);
+            break;
+
+        case SHT3X_LOALRT_SET:
+            ret = sensirion_i2c_read_cmd(addr, SHT3X_CMD_READ_LOALRT_LIM_SET,
+                                         &word, 1);
+            break;
+
+        default:
+            ret = STATUS_ERR_INVALID_PARAMS;
+            break;
+    }
+
+    /* convert threshold word to alrt settings in 10*%RH & 10*°C */
+    tmp = (int32_t)(word & SHT3X_HUMIDITY_LIMIT_MSK); /*only 7MSbits*/
+    tmp = (1000 * tmp) / 65535;
+    *humidity = tmp;
+
+    tmp = (int32_t)(word & SHT3X_TEMPERATURE_LIMIT_MSK); /*only 9LSbits*/
+    tmp = (tmp << 7);
+    tmp = (tmp * 1750) / 65535;
+    tmp = tmp - 450;
+    *temperature = (int16_t)tmp;
+
+    return ret;
 }

--- a/sht3x/sht3x.c
+++ b/sht3x/sht3x.c
@@ -54,33 +54,30 @@
 static const uint16_t SHT3X_CMD_READ_STATUS_REG = 0xF32D;
 static const uint16_t SHT3X_CMD_READ_SERIAL_ID = 0x3780;
 static const uint16_t SHT3X_CMD_DURATION_USEC = 1000;
-#ifdef SHT_ADDRESS
-static const uint8_t SHT3X_ADDRESS = SHT_ADDRESS;
-#else
-static const uint8_t SHT3X_ADDRESS = 0x44;
-#endif
 
 static uint16_t sht3x_cmd_measure = SHT3X_CMD_MEASURE_HPM;
 
-int16_t sht3x_measure_blocking_read(int32_t* temperature, int32_t* humidity) {
-    int16_t ret = sht3x_measure();
+int16_t sht3x_measure_blocking_read(sht3x_i2c_addr_t addr, int32_t* temperature,
+                                    int32_t* humidity) {
+    int16_t ret = sht3x_measure(addr);
     if (ret == STATUS_OK) {
 #if !defined(USE_SENSIRION_CLOCK_STRETCHING) || !USE_SENSIRION_CLOCK_STRETCHING
         sensirion_sleep_usec(SHT3X_MEASUREMENT_DURATION_USEC);
 #endif /* USE_SENSIRION_CLOCK_STRETCHING */
-        ret = sht3x_read(temperature, humidity);
+        ret = sht3x_read(addr, temperature, humidity);
     }
     return ret;
 }
 
-int16_t sht3x_measure(void) {
-    return sensirion_i2c_write_cmd(SHT3X_ADDRESS, sht3x_cmd_measure);
+int16_t sht3x_measure(sht3x_i2c_addr_t addr) {
+    return sensirion_i2c_write_cmd(addr, sht3x_cmd_measure);
 }
 
-int16_t sht3x_read(int32_t* temperature, int32_t* humidity) {
+int16_t sht3x_read(sht3x_i2c_addr_t addr, int32_t* temperature,
+                   int32_t* humidity) {
     uint16_t words[2];
-    int16_t ret = sensirion_i2c_read_words(SHT3X_ADDRESS, words,
-                                           SENSIRION_NUM_WORDS(words));
+    int16_t ret =
+        sensirion_i2c_read_words(addr, words, SENSIRION_NUM_WORDS(words));
     /**
      * formulas for conversion of the sensor signals, optimized for fixed point
      * algebra: Temperature = 175 * S_T / 2^16 - 45
@@ -92,10 +89,9 @@ int16_t sht3x_read(int32_t* temperature, int32_t* humidity) {
     return ret;
 }
 
-int16_t sht3x_probe(void) {
+int16_t sht3x_probe(sht3x_i2c_addr_t addr) {
     uint16_t status;
-    return sensirion_i2c_delayed_read_cmd(SHT3X_ADDRESS,
-                                          SHT3X_CMD_READ_STATUS_REG,
+    return sensirion_i2c_delayed_read_cmd(addr, SHT3X_CMD_READ_STATUS_REG,
                                           SHT3X_CMD_DURATION_USEC, &status, 1);
 }
 
@@ -104,26 +100,26 @@ void sht3x_enable_low_power_mode(uint8_t enable_low_power_mode) {
         enable_low_power_mode ? SHT3X_CMD_MEASURE_LPM : SHT3X_CMD_MEASURE_HPM;
 }
 
-int16_t sht3x_read_serial(uint32_t* serial) {
+int16_t sht3x_read_serial(sht3x_i2c_addr_t addr, uint32_t* serial) {
     int16_t ret;
     uint8_t serial_bytes[4];
 
-    ret = sensirion_i2c_write_cmd(SHT3X_ADDRESS, SHT3X_CMD_READ_SERIAL_ID);
-    if (ret)
-        return ret;
-
+    ret = sensirion_i2c_write_cmd(addr, SHT3X_CMD_READ_SERIAL_ID);
     sensirion_sleep_usec(SHT3X_CMD_DURATION_USEC);
 
-    ret = sensirion_i2c_read_words_as_bytes(SHT3X_ADDRESS, serial_bytes,
-                                            SENSIRION_NUM_WORDS(serial_bytes));
-    *serial = sensirion_bytes_to_uint32_t(serial_bytes);
+    if (ret == STATUS_OK) {
+
+        ret = sensirion_i2c_read_words_as_bytes(
+            addr, serial_bytes, SENSIRION_NUM_WORDS(serial_bytes));
+        *serial = sensirion_bytes_to_uint32_t(serial_bytes);
+    }
     return ret;
 }
 
-const char* sht3x_get_driver_version(void) {
+const char* sht3x_get_driver_version(sht3x_i2c_addr_t addr) {
     return SHT_DRV_VERSION_STR;
 }
 
-uint8_t sht3x_get_configured_address(void) {
-    return SHT3X_ADDRESS;
+uint8_t sht3x_get_configured_address(sht3x_i2c_addr_t addr) {
+    return addr;
 }

--- a/sht3x/sht3x.h
+++ b/sht3x/sht3x.h
@@ -107,7 +107,7 @@ int16_t sht3x_probe(sht3x_i2c_addr_t addr);
  * @param[in] addr the sensor address
  * @param[out] status  the address for the result of the status word
  *
- * @return 0 if a sensor was detected
+ *  @return 0 if the command was successful, else an error code
  */
 int16_t sht3x_get_status(sht3x_i2c_addr_t addr, uint16_t* status);
 
@@ -116,7 +116,7 @@ int16_t sht3x_get_status(sht3x_i2c_addr_t addr, uint16_t* status);
  *
  * @param[in] addr the sensor address
  *
- * @return 0 if a sensor was detected
+ *  @return 0 if the command was successful, else an error code
  */
 int16_t sht3x_clear_status(sht3x_i2c_addr_t addr);
 
@@ -175,7 +175,7 @@ int16_t sht3x_read(sht3x_i2c_addr_t addr, int32_t* temperature,
 void sht3x_enable_low_power_mode(uint8_t enable_low_power_mode);
 
 /**
- * @brief Enable or disable the SHT's low power mode
+ * @brief Set the desired sensor's operating power mode
  *
  * @param[in] mode power mode selector
  */
@@ -203,26 +203,58 @@ const char* sht3x_get_driver_version(void);
  *
  * @param[in] addr the sensor address
  * @param[in] thd target alert threshold to be edited
- * @param[in] humidity humidity threshold in 10*%RH
- * @param[in] temperature temperature threshold in 10*%°C
+ * @param[in] humidity humidity threshold in 1000*%RH
+ * @param[in] temperature temperature threshold in 1000*°C
  *
  * @return          0 if the command was successful, else an error code.
  */
 int16_t sht3x_set_alert_thd(sht3x_i2c_addr_t addr, sht3x_alert_thd_t thd,
-                            uint16_t humidity, int16_t temperature);
+                            uint32_t humidity, int32_t temperature);
 
 /**
  * @brief Get target temperature and humidity alert threshold
  *
  * @param[in]  addr the sensor address
- * @param[in] thd target alert threshold to be edited
- * @param[out] humidity address for the result humidity thd in 10*%RH
- * @param[out] temperature address for the result temperature thd in 10*°C
+ * @param[in]  thd target alert threshold to be edited
+ * @param[out] humidity address for the result humidity thd in 1000*%RH
+ * @param[out] temperature address for the result temperature thd in 1000*°C
  *
  * @return          0 if the command was successful, else an error code.
  */
 int16_t sht3x_get_alert_thd(sht3x_i2c_addr_t addr, sht3x_alert_thd_t thd,
-                            uint16_t* humidity, int16_t* temperature);
+                            int32_t* humidity, int32_t* temperature);
+
+/**
+ * @brief converts temperature from ADC ticks
+ *
+ * @param tick sensor ADC ticks
+ * @param temperature temperature value in T°C*1000
+ */
+void tick_to_temperature(uint16_t tick, int32_t* temperature);
+
+/**
+ * @brief converts humidity from ADC ticks
+ *
+ * @param tick sensor ADC ticks
+ * @param humidity humidity value in %*1000
+ */
+void tick_to_humidity(uint16_t tick, int32_t* humidity);
+
+/**
+ * @brief converts temperature to ADC ticks
+ *
+ * @param temperature temperature value in T°C*1000
+ * @param tick sensor ADC ticks
+ */
+void temperature_to_tick(int32_t temperature, uint16_t* tick);
+
+/**
+ * @brief converts humidity to ADC ticks
+ *
+ * @param humidity humidity value in %*1000
+ * @param tick sensor ADC ticks
+ */
+void humidity_to_tick(int32_t humidity, uint16_t* tick);
 
 #ifdef __cplusplus
 }

--- a/sht3x/sht3x.h
+++ b/sht3x/sht3x.h
@@ -56,13 +56,23 @@ extern "C" {
 #define SHT3X_MEASUREMENT_DURATION_USEC 15000
 
 /**
+ * @brief SHT3x I2C 7-bit address option
+ */
+typedef enum _sht3x_i2c_addr {
+    SHT3X_I2C_ADDR_DFLT = 0x44,
+    SHT3X_I2C_ADDR_ALT = 0x45
+} sht3x_i2c_addr_t;
+
+/**
  * Detects if a sensor is connected by reading out the ID register.
  * If the sensor does not answer or if the answer is not the expected value,
  * the test fails.
  *
+ * @param[in] addr the sensor address
+ *
  * @return 0 if a sensor was detected
  */
-int16_t sht3x_probe(void);
+int16_t sht3x_probe(sht3x_i2c_addr_t addr);
 
 /**
  * Starts a measurement and then reads out the results. This function blocks
@@ -71,22 +81,27 @@ int16_t sht3x_probe(void);
  * Temperature is returned in [degree Celsius], multiplied by 1000,
  * and relative humidity in [percent relative humidity], multiplied by 1000.
  *
- * @param temperature   the address for the result of the temperature
+ * @param[in]  addr the sensor address
+ * @param[out] temperature   the address for the result of the temperature
  * measurement
- * @param humidity      the address for the result of the relative humidity
+ * @param[out] humidity      the address for the result of the relative humidity
  * measurement
+ *
  * @return              0 if the command was successful, else an error code.
  */
-int16_t sht3x_measure_blocking_read(int32_t* temperature, int32_t* humidity);
+int16_t sht3x_measure_blocking_read(sht3x_i2c_addr_t addr, int32_t* temperature,
+                                    int32_t* humidity);
 
 /**
  * Starts a measurement in high precision mode. Use sht3x_read() to read out the
  * values, once the measurement is done. The duration of the measurement depends
  * on the sensor in use, please consult the datasheet.
  *
+ * @param[in]  addr the sensor address
+ *
  * @return     0 if the command was successful, else an error code.
  */
-int16_t sht3x_measure(void);
+int16_t sht3x_measure(sht3x_i2c_addr_t addr);
 
 /**
  * Reads out the results of a measurement that was previously started by
@@ -95,42 +110,51 @@ int16_t sht3x_measure(void);
  * Temperature is returned in [degree Celsius], multiplied by 1000,
  * and relative humidity in [percent relative humidity], multiplied by 1000.
  *
- * @param temperature   the address for the result of the temperature
+ * @param[in]  addr the sensor address
+ * @param[out] temperature   the address for the result of the temperature
  * measurement
- * @param humidity      the address for the result of the relative humidity
+ * @param[out] humidity      the address for the result of the relative humidity
  * measurement
+ *
  * @return              0 if the command was successful, else an error code.
  */
-int16_t sht3x_read(int32_t* temperature, int32_t* humidity);
+int16_t sht3x_read(sht3x_i2c_addr_t addr, int32_t* temperature,
+                   int32_t* humidity);
 
 /**
  * Enable or disable the SHT's low power mode
  *
- * @param enable_low_power_mode 1 to enable low power mode, 0 to disable
+ * @param[in] enable_low_power_mode 1 to enable low power mode, 0 to disable
  */
 void sht3x_enable_low_power_mode(uint8_t enable_low_power_mode);
 
 /**
  * Read out the serial number
  *
- * @param serial    the address for the result of the serial number
+ * @param[in]  addr the sensor address
+ * @param[out] serial    the address for the result of the serial number
+ *
  * @return          0 if the command was successful, else an error code.
  */
-int16_t sht3x_read_serial(uint32_t* serial);
+int16_t sht3x_read_serial(sht3x_i2c_addr_t addr, uint32_t* serial);
 
 /**
  * Return the driver version
  *
+ * @param[in]  addr the sensor address
+ *
  * @return Driver version string
  */
-const char* sht3x_get_driver_version(void);
+const char* sht3x_get_driver_version(sht3x_i2c_addr_t addr);
 
 /**
  * Returns the configured SHT3x address.
  *
+ * @param[in]  addr the sensor address
+ *
  * @return SHT3x_ADDRESS
  */
-uint8_t sht3x_get_configured_address(void);
+uint8_t sht3x_get_configured_address(sht3x_i2c_addr_t addr);
 
 #ifdef __cplusplus
 }

--- a/sht3x/sht3x.h
+++ b/sht3x/sht3x.h
@@ -53,7 +53,15 @@ extern "C" {
 #define STATUS_ERR_BAD_DATA (-1)
 #define STATUS_CRC_FAIL (-2)
 #define STATUS_UNKNOWN_DEVICE (-3)
+#define STATUS_ERR_INVALID_PARAMS (-4)
 #define SHT3X_MEASUREMENT_DURATION_USEC 15000
+
+/* status word macros */
+#define SHT3X_IS_ALRT_PENDING(status) (bool)(((status)&0x8000U) != 0U)
+#define SHT3X_IS_ALRT_RH_TRACK(status) (bool)(((status)&0x0800) != 0U)
+#define SHT3X_IS_ALRT_T_TRACK(status) (bool)(((status)&0x0400U) != 0U)
+#define SHT3X_IS_SYSTEM_RST_DETECT(status) (bool)(((status)&0x0010U) != 0U)
+#define SHT3X_IS_LAST_CRC_FAIL(status) (bool)(((status)&0x0001U) != 0U)
 
 /**
  * @brief SHT3x I2C 7-bit address option
@@ -62,6 +70,25 @@ typedef enum _sht3x_i2c_addr {
     SHT3X_I2C_ADDR_DFLT = 0x44,
     SHT3X_I2C_ADDR_ALT = 0x45
 } sht3x_i2c_addr_t;
+
+/**
+ * @brief SHT3x I2C 7-bit address option
+ */
+typedef enum _sht3x_measurement_mode {
+    SHT3X_MEAS_MODE_LPM, /*low power mode*/
+    SHT3X_MEAS_MODE_MPM, /*medium power mode*/
+    SHT3X_MEAS_MODE_HPM  /*high power mode*/
+} sht3x_measurement_mode_t;
+
+/**
+ * @brief SHT3x Alert Thresholds
+ */
+typedef enum _sht3x_alert_thd {
+    SHT3X_HIALRT_SET,
+    SHT3X_HIALRT_CLR,
+    SHT3X_LOALRT_CLR,
+    SHT3X_LOALRT_SET,
+} sht3x_alert_thd_t;
 
 /**
  * Detects if a sensor is connected by reading out the ID register.
@@ -73,6 +100,25 @@ typedef enum _sht3x_i2c_addr {
  * @return 0 if a sensor was detected
  */
 int16_t sht3x_probe(sht3x_i2c_addr_t addr);
+
+/**
+ * Read the sensot status word
+ *
+ * @param[in] addr the sensor address
+ * @param[out] status  the address for the result of the status word
+ *
+ * @return 0 if a sensor was detected
+ */
+int16_t sht3x_get_status(sht3x_i2c_addr_t addr, uint16_t* status);
+
+/**
+ * Clear the status register alert flags
+ *
+ * @param[in] addr the sensor address
+ *
+ * @return 0 if a sensor was detected
+ */
+int16_t sht3x_clear_status(sht3x_i2c_addr_t addr);
 
 /**
  * Starts a measurement and then reads out the results. This function blocks
@@ -129,6 +175,13 @@ int16_t sht3x_read(sht3x_i2c_addr_t addr, int32_t* temperature,
 void sht3x_enable_low_power_mode(uint8_t enable_low_power_mode);
 
 /**
+ * Enable or disable the SHT's low power mode
+ *
+ * @param[in] mode power mode selector
+ */
+void sht3x_set_power_mode(sht3x_measurement_mode_t mode);
+
+/**
  * Read out the serial number
  *
  * @param[in]  addr the sensor address
@@ -155,6 +208,32 @@ const char* sht3x_get_driver_version(sht3x_i2c_addr_t addr);
  * @return SHT3x_ADDRESS
  */
 uint8_t sht3x_get_configured_address(sht3x_i2c_addr_t addr);
+
+/**
+ * Set target temperature and humidity alrt threshold
+ *
+ * @param[in] addr the sensor address
+ * @param[in] thd target alert threshold to be edited
+ * @param[in] humidity humidity threshold in 10*%RH
+ * @param[in] temperature temperature threshold in 10*%°C
+ *
+ * @return          0 if the command was successful, else an error code.
+ */
+int16_t sht3x_set_alert_thd(sht3x_i2c_addr_t addr, sht3x_alert_thd_t thd,
+                            uint16_t humidity, int16_t temperature);
+
+/**
+ * Get target temperature and humidity alrt threshold
+ *
+ * @param[in]  addr the sensor address
+ *  @param[in] thd target alert threshold to be edited
+ * @param[out] humidity address for the result humidity thd in 10*%RH
+ * @param[out] temperature address for the result temperature thd in 10*°C
+ *
+ * @return          0 if the command was successful, else an error code.
+ */
+int16_t sht3x_get_alert_thd(sht3x_i2c_addr_t addr, sht3x_alert_thd_t thd,
+                            uint16_t* humidity, int16_t* temperature);
 
 #ifdef __cplusplus
 }

--- a/sht3x/sht3x.h
+++ b/sht3x/sht3x.h
@@ -57,11 +57,11 @@ extern "C" {
 #define SHT3X_MEASUREMENT_DURATION_USEC 15000
 
 /* status word macros */
-#define SHT3X_IS_ALRT_PENDING(status) (bool)(((status)&0x8000U) != 0U)
-#define SHT3X_IS_ALRT_RH_TRACK(status) (bool)(((status)&0x0800) != 0U)
-#define SHT3X_IS_ALRT_T_TRACK(status) (bool)(((status)&0x0400U) != 0U)
-#define SHT3X_IS_SYSTEM_RST_DETECT(status) (bool)(((status)&0x0010U) != 0U)
-#define SHT3X_IS_LAST_CRC_FAIL(status) (bool)(((status)&0x0001U) != 0U)
+#define SHT3X_IS_ALRT_PENDING(status) (((status)&0x8000U) != 0U)
+#define SHT3X_IS_ALRT_RH_TRACK(status) (((status)&0x0800) != 0U)
+#define SHT3X_IS_ALRT_T_TRACK(status) (((status)&0x0400U) != 0U)
+#define SHT3X_IS_SYSTEM_RST_DETECT(status) (((status)&0x0010U) != 0U)
+#define SHT3X_IS_LAST_CRC_FAIL(status) (((status)&0x0001U) != 0U)
 
 /**
  * @brief SHT3x I2C 7-bit address option
@@ -72,7 +72,7 @@ typedef enum _sht3x_i2c_addr {
 } sht3x_i2c_addr_t;
 
 /**
- * @brief SHT3x I2C 7-bit address option
+ * @brief SHT3x measurment mode options (Low, Medium and High rerefresh rates)
  */
 typedef enum _sht3x_measurement_mode {
     SHT3X_MEAS_MODE_LPM, /*low power mode*/
@@ -91,7 +91,7 @@ typedef enum _sht3x_alert_thd {
 } sht3x_alert_thd_t;
 
 /**
- * Detects if a sensor is connected by reading out the ID register.
+ * @brief Detects if a sensor is connected by reading out the ID register.
  * If the sensor does not answer or if the answer is not the expected value,
  * the test fails.
  *
@@ -102,7 +102,7 @@ typedef enum _sht3x_alert_thd {
 int16_t sht3x_probe(sht3x_i2c_addr_t addr);
 
 /**
- * Read the sensot status word
+ * @brief Read the sensor status word
  *
  * @param[in] addr the sensor address
  * @param[out] status  the address for the result of the status word
@@ -112,7 +112,7 @@ int16_t sht3x_probe(sht3x_i2c_addr_t addr);
 int16_t sht3x_get_status(sht3x_i2c_addr_t addr, uint16_t* status);
 
 /**
- * Clear the status register alert flags
+ * @brief Clear the status register alert flags
  *
  * @param[in] addr the sensor address
  *
@@ -121,11 +121,11 @@ int16_t sht3x_get_status(sht3x_i2c_addr_t addr, uint16_t* status);
 int16_t sht3x_clear_status(sht3x_i2c_addr_t addr);
 
 /**
- * Starts a measurement and then reads out the results. This function blocks
- * while the measurement is in progress. The duration of the measurement depends
- * on the sensor in use, please consult the datasheet.
- * Temperature is returned in [degree Celsius], multiplied by 1000,
- * and relative humidity in [percent relative humidity], multiplied by 1000.
+ * @brief Starts a measurement and then reads out the results. This function
+ * blocks while the measurement is in progress. The duration of the measurement
+ * depends on the sensor in use, please consult the datasheet. Temperature is
+ * returned in [degree Celsius], multiplied by 1000, and relative humidity in
+ * [percent relative humidity], multiplied by 1000.
  *
  * @param[in]  addr the sensor address
  * @param[out] temperature   the address for the result of the temperature
@@ -139,9 +139,9 @@ int16_t sht3x_measure_blocking_read(sht3x_i2c_addr_t addr, int32_t* temperature,
                                     int32_t* humidity);
 
 /**
- * Starts a measurement in high precision mode. Use sht3x_read() to read out the
- * values, once the measurement is done. The duration of the measurement depends
- * on the sensor in use, please consult the datasheet.
+ * @brief Starts a measurement in high precision mode. Use sht3x_read() to read
+ * out the values, once the measurement is done. The duration of the measurement
+ * depends on the sensor in use, please consult the datasheet.
  *
  * @param[in]  addr the sensor address
  *
@@ -150,7 +150,7 @@ int16_t sht3x_measure_blocking_read(sht3x_i2c_addr_t addr, int32_t* temperature,
 int16_t sht3x_measure(sht3x_i2c_addr_t addr);
 
 /**
- * Reads out the results of a measurement that was previously started by
+ * @brief Reads out the results of a measurement that was previously started by
  * sht3x_measure(). If the measurement is still in progress, this function
  * returns an error.
  * Temperature is returned in [degree Celsius], multiplied by 1000,
@@ -168,21 +168,21 @@ int16_t sht3x_read(sht3x_i2c_addr_t addr, int32_t* temperature,
                    int32_t* humidity);
 
 /**
- * Enable or disable the SHT's low power mode
+ * @brief Enable or disable the SHT's low power mode
  *
  * @param[in] enable_low_power_mode 1 to enable low power mode, 0 to disable
  */
 void sht3x_enable_low_power_mode(uint8_t enable_low_power_mode);
 
 /**
- * Enable or disable the SHT's low power mode
+ * @brief Enable or disable the SHT's low power mode
  *
  * @param[in] mode power mode selector
  */
 void sht3x_set_power_mode(sht3x_measurement_mode_t mode);
 
 /**
- * Read out the serial number
+ * @brief Read out the serial number
  *
  * @param[in]  addr the sensor address
  * @param[out] serial    the address for the result of the serial number
@@ -192,25 +192,14 @@ void sht3x_set_power_mode(sht3x_measurement_mode_t mode);
 int16_t sht3x_read_serial(sht3x_i2c_addr_t addr, uint32_t* serial);
 
 /**
- * Return the driver version
- *
- * @param[in]  addr the sensor address
+ * @brief Return the driver version
  *
  * @return Driver version string
  */
-const char* sht3x_get_driver_version(sht3x_i2c_addr_t addr);
+const char* sht3x_get_driver_version(void);
 
 /**
- * Returns the configured SHT3x address.
- *
- * @param[in]  addr the sensor address
- *
- * @return SHT3x_ADDRESS
- */
-uint8_t sht3x_get_configured_address(sht3x_i2c_addr_t addr);
-
-/**
- * Set target temperature and humidity alrt threshold
+ * @brief Set target temperature and humidity alert threshold
  *
  * @param[in] addr the sensor address
  * @param[in] thd target alert threshold to be edited
@@ -223,7 +212,7 @@ int16_t sht3x_set_alert_thd(sht3x_i2c_addr_t addr, sht3x_alert_thd_t thd,
                             uint16_t humidity, int16_t temperature);
 
 /**
- * Get target temperature and humidity alrt threshold
+ * @brief Get target temperature and humidity alert threshold
  *
  * @param[in]  addr the sensor address
  *  @param[in] thd target alert threshold to be edited

--- a/sht3x/sht3x.h
+++ b/sht3x/sht3x.h
@@ -215,7 +215,7 @@ int16_t sht3x_set_alert_thd(sht3x_i2c_addr_t addr, sht3x_alert_thd_t thd,
  * @brief Get target temperature and humidity alert threshold
  *
  * @param[in]  addr the sensor address
- *  @param[in] thd target alert threshold to be edited
+ * @param[in] thd target alert threshold to be edited
  * @param[out] humidity address for the result humidity thd in 10*%RH
  * @param[out] temperature address for the result temperature thd in 10*°C
  *

--- a/sht3x/sht3x_example_usage.c
+++ b/sht3x/sht3x_example_usage.c
@@ -45,7 +45,7 @@ int main(void) {
     /* Busy loop for initialization, because the main loop does not work without
      * a sensor.
      */
-    while (sht3x_probe() != STATUS_OK) {
+    while (sht3x_probe(SHT3X_I2C_ADDR_DFLT) != STATUS_OK) {
         printf("SHT sensor probing failed\n");
     }
     printf("SHT sensor probing successful\n");
@@ -55,7 +55,8 @@ int main(void) {
         /* Measure temperature and relative humidity and store into variables
          * temperature, humidity (each output multiplied by 1000).
          */
-        int8_t ret = sht3x_measure_blocking_read(&temperature, &humidity);
+        int8_t ret = sht3x_measure_blocking_read(SHT3X_I2C_ADDR_DFLT,
+                                                 &temperature, &humidity);
         if (ret == STATUS_OK) {
             printf("measured temperature: %0.2f degreeCelsius, "
                    "measured humidity: %0.2f percentRH\n",

--- a/tests/sht3x-test.cpp
+++ b/tests/sht3x-test.cpp
@@ -8,37 +8,38 @@ static void sht3x_run_test() {
     int32_t humidity;
     uint32_t serial;
 
-    ret = sht3x_measure_blocking_read(&temperature, &humidity);
+    ret = sht3x_measure_blocking_read(SHT3X_I2C_ADDR_DFLT, &temperature,
+                                      &humidity);
     CHECK_ZERO_TEXT(ret, "sht3x_measure_blocking_read");
     CHECK_TRUE_TEXT(temperature >= 5000 && temperature <= 45000,
                     "sht3x_measure_blocking_read temperature");
     CHECK_TRUE_TEXT(humidity >= 0 && humidity <= 100000,
                     "sht3x_measure_blocking_read humidity");
 
-    ret = sht3x_measure();
+    ret = sht3x_measure(SHT3X_I2C_ADDR_DFLT);
     CHECK_ZERO_TEXT(ret, "sht3x_measure");
 
     sensirion_sleep_usec(SHT3X_MEASUREMENT_DURATION_USEC);
 
-    ret = sht3x_read(&temperature, &humidity);
+    ret = sht3x_read(SHT3X_I2C_ADDR_DFLT, &temperature, &humidity);
     CHECK_ZERO_TEXT(ret, "sht3x_read");
     CHECK_TRUE_TEXT(temperature >= 5000 && temperature <= 45000,
                     "sht3x_read temperature");
     CHECK_TRUE_TEXT(humidity >= 0 && humidity <= 100000, "sht3x_read humidity");
 
-    ret = sht3x_read_serial(&serial);
+    ret = sht3x_read_serial(SHT3X_I2C_ADDR_DFLT, &serial);
     CHECK_ZERO_TEXT(ret, "sht3x_read_serial");
     printf("SHT3X serial: %u\n", serial);
 
     const char* version = sht3x_get_driver_version();
     printf("sht3x_get_driver_version: %s\n", version);
 
-    uint8_t addr = sht3x_get_configured_address();
+    uint8_t addr = sht3x_get_configured_address(SHT3X_I2C_ADDR_DFLT);
     CHECK_EQUAL_TEXT(0x44, addr, "sht3x_get_configured_address");
 }
 
 static void sht3x_test_all_power_modes() {
-    int16_t ret = sht3x_probe();
+    int16_t ret = sht3x_probe(SHT3X_I2C_ADDR_DFLT);
     CHECK_ZERO_TEXT(ret, "sht3x_probe");
 
     printf("Running tests in normal mode...\n");

--- a/tests/sht3x-test.cpp
+++ b/tests/sht3x-test.cpp
@@ -33,9 +33,6 @@ static void sht3x_run_test() {
 
     const char* version = sht3x_get_driver_version();
     printf("sht3x_get_driver_version: %s\n", version);
-
-    uint8_t addr = sht3x_get_configured_address(SHT3X_I2C_ADDR_DFLT);
-    CHECK_EQUAL_TEXT(0x44, addr, "sht3x_get_configured_address");
 }
 
 static void sht3x_test_all_power_modes() {


### PR DESCRIPTION
Check the following:

 - [x] Breaking changes marked in commit message
 - [x] Changelog updated
 - [x] Code style cleaned (ran `make style-fix`)
 - [x] Tested on actual hardware
